### PR TITLE
Camera preview fix

### DIFF
--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -56,7 +57,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.vtubercamera.ui.components.AsyncImage
@@ -74,14 +74,14 @@ fun CameraScreen(
     val isPreviewMode by viewModel.isPreviewMode.collectAsStateWithLifecycle()
     val flashMode by viewModel.flashMode.collectAsStateWithLifecycle()
     val zoomRatio by viewModel.zoomRatio.collectAsStateWithLifecycle()
-    
-    // カメラ状態管理の改善
+    val cameraRebindTrigger by viewModel.cameraRebindTrigger.collectAsStateWithLifecycle()
+
+    // カメラ状態管理
     var imageCapture: ImageCapture? by remember { mutableStateOf(null) }
     var camera: Camera? by remember { mutableStateOf(null) }
     var cameraProvider: ProcessCameraProvider? by remember { mutableStateOf(null) }
     var previewView: PreviewView? by remember { mutableStateOf(null) }
-    var preview: Preview? by remember { mutableStateOf(null) }
-    
+
     var hasCameraPermission by remember {
         mutableStateOf(
             ContextCompat.checkSelfPermission(
@@ -101,6 +101,64 @@ fun CameraScreen(
     LaunchedEffect(Unit) {
         if (!hasCameraPermission) {
             launcher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    // カメラプロバイダーの初期化
+    LaunchedEffect(Unit) {
+        if (hasCameraPermission) {
+            val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+            cameraProviderFuture.addListener({
+                cameraProvider = cameraProviderFuture.get()
+            }, ContextCompat.getMainExecutor(context))
+        }
+    }
+
+    // カメラの再バインド処理（プレビューモードからの復帰時も含む）
+    LaunchedEffect(cameraSelector, flashMode, cameraRebindTrigger) {
+        if (cameraProvider != null && previewView != null && !isPreviewMode) {
+            Log.d(
+                "CameraScreen",
+                "Rebinding camera - Selector: ${if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) "BACK" else "FRONT"}, Flash: $flashMode, Trigger: $cameraRebindTrigger"
+            )
+
+            try {
+                // 既存のバインディングを解除
+                cameraProvider!!.unbindAll()
+
+                // 新しいプレビューとImageCaptureを作成
+                val preview = Preview.Builder().build()
+                val newImageCapture = ImageCapture.Builder()
+                    .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)
+                    .setFlashMode(flashMode)
+                    .build()
+
+                // SurfaceProviderを設定
+                preview.surfaceProvider = previewView!!.surfaceProvider
+
+                // カメラをバインド
+                val newCamera = cameraProvider!!.bindToLifecycle(
+                    lifecycleOwner,
+                    cameraSelector,
+                    preview,
+                    newImageCapture
+                )
+
+                imageCapture = newImageCapture
+                camera = newCamera
+                viewModel.setCamera(newCamera)
+
+                Log.d("CameraScreen", "Camera rebound successfully")
+            } catch (e: Exception) {
+                Log.e("CameraScreen", "Failed to rebind camera", e)
+            }
+        }
+    }
+
+    // クリーンアップ
+    DisposableEffect(Unit) {
+        onDispose {
+            cameraProvider?.unbindAll()
         }
     }
 
@@ -136,6 +194,7 @@ fun CameraScreen(
         ) {
             if (hasCameraPermission) {
                 if (isPreviewMode && lastCapturedImageUri != null) {
+                    // 写真プレビューモード
                     Box(modifier = Modifier.fillMaxSize()) {
                         AsyncImage(
                             model = lastCapturedImageUri!!,
@@ -165,7 +224,7 @@ fun CameraScreen(
                         }
                     }
                 } else {
-                    // AndroidViewの改善
+                    // カメラプレビューモード
                     AndroidView(
                         factory = { ctx ->
                             PreviewView(ctx).apply {
@@ -173,63 +232,14 @@ fun CameraScreen(
                                     ViewGroup.LayoutParams.MATCH_PARENT,
                                     ViewGroup.LayoutParams.MATCH_PARENT
                                 )
-                                previewView = this // PreviewViewの参照を保存
+                                previewView = this
+                                Log.d("CameraScreen", "PreviewView created")
                             }
                         },
                         modifier = Modifier.fillMaxSize()
-                    ) { view ->
-                        // 初回のみカメラプロバイダーを初期化
-                        if (cameraProvider == null) {
-                            val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
-                            cameraProviderFuture.addListener({
-                                cameraProvider = cameraProviderFuture.get()
-                                
-                                // プレビューを一度だけ作成してSurfaceProviderを設定
-                                preview = Preview.Builder().build().also {
-                                    it.setSurfaceProvider(view.surfaceProvider)
-                                }
-                                
-                                // 初回バインド
-                                bindCameraWithPreview(
-                                    lifecycleOwner = lifecycleOwner,
-                                    cameraProvider = cameraProvider!!,
-                                    preview = preview!!,
-                                    cameraSelector = cameraSelector,
-                                    flashMode = flashMode,
-                                    onImageCaptureCreated = { capture ->
-                                        imageCapture = capture
-                                    },
-                                    onCameraCreated = { cam ->
-                                        camera = cam
-                                        viewModel.setCamera(cam)
-                                    }
-                                )
-                            }, ContextCompat.getMainExecutor(context))
-                        }
-                    }
+                    )
 
-                    // 状態変更の監視と賢い再バインド
-                    LaunchedEffect(cameraSelector, flashMode, isPreviewMode) {
-                        // カメラプロバイダーとプレビューが準備できている場合のみ再バインド
-                        if (cameraProvider != null && preview != null) {
-                            Log.d("CameraScreen", "Rebinding camera due to state change")
-                            bindCameraWithPreview(
-                                lifecycleOwner = lifecycleOwner,
-                                cameraProvider = cameraProvider!!,
-                                preview = preview!!, // 既存のプレビューを再利用
-                                cameraSelector = cameraSelector,
-                                flashMode = flashMode,
-                                onImageCaptureCreated = { capture ->
-                                    imageCapture = capture
-                                },
-                                onCameraCreated = { cam ->
-                                    camera = cam
-                                    viewModel.setCamera(cam)
-                                }
-                            )
-                        }
-                    }
-
+                    // コントロールUI
                     Row(
                         modifier = Modifier
                             .align(Alignment.BottomStart)
@@ -311,47 +321,5 @@ fun CameraScreen(
                 }
             }
         }
-    }
-}
-
-// 既存のPreviewを再利用するバインド関数
-private fun bindCameraWithPreview(
-    lifecycleOwner: LifecycleOwner,
-    cameraProvider: ProcessCameraProvider,
-    preview: Preview, // 既存のPreviewを受け取る
-    cameraSelector: CameraSelector,
-    flashMode: Int,
-    onImageCaptureCreated: (ImageCapture) -> Unit,
-    onCameraCreated: (Camera) -> Unit
-): Camera? {
-    return try {
-        Log.d("CameraBinding", "Binding camera with flash mode: $flashMode, camera: ${if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) "BACK" else "FRONT"}")
-
-        // ImageCaptureのみ新しく作成（フラッシュモードを反映）
-        val imageCapture = ImageCapture.Builder()
-            .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)
-            .setFlashMode(flashMode)
-            .build()
-
-        // 既存のバインディングを解除
-        cameraProvider.unbindAll()
-        
-        // 既存のPreviewと新しいImageCaptureでバインド
-        val camera = cameraProvider.bindToLifecycle(
-            lifecycleOwner,
-            cameraSelector,
-            preview, // 既存のPreviewを再利用
-            imageCapture
-        )
-
-        onImageCaptureCreated(imageCapture)
-        onCameraCreated(camera)
-        
-        Log.d("CameraBinding", "Camera bound successfully")
-        
-        camera
-    } catch (e: Exception) {
-        Log.e("CameraBinding", "カメラのバインドに失敗しました", e)
-        null
     }
 }

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -57,6 +56,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.vtubercamera.ui.components.AsyncImage
@@ -74,13 +74,14 @@ fun CameraScreen(
     val isPreviewMode by viewModel.isPreviewMode.collectAsStateWithLifecycle()
     val flashMode by viewModel.flashMode.collectAsStateWithLifecycle()
     val zoomRatio by viewModel.zoomRatio.collectAsStateWithLifecycle()
-    val cameraRebindTrigger by viewModel.cameraRebindTrigger.collectAsStateWithLifecycle()
+    val needsCameraRebind by viewModel.needsCameraRebind.collectAsStateWithLifecycle()
 
-    // カメラ状態管理
+    // カメラ状態管理の改善
     var imageCapture: ImageCapture? by remember { mutableStateOf(null) }
     var camera: Camera? by remember { mutableStateOf(null) }
     var cameraProvider: ProcessCameraProvider? by remember { mutableStateOf(null) }
     var previewView: PreviewView? by remember { mutableStateOf(null) }
+    var preview: Preview? by remember { mutableStateOf(null) }
 
     var hasCameraPermission by remember {
         mutableStateOf(
@@ -101,64 +102,6 @@ fun CameraScreen(
     LaunchedEffect(Unit) {
         if (!hasCameraPermission) {
             launcher.launch(Manifest.permission.CAMERA)
-        }
-    }
-
-    // カメラプロバイダーの初期化
-    LaunchedEffect(Unit) {
-        if (hasCameraPermission) {
-            val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
-            cameraProviderFuture.addListener({
-                cameraProvider = cameraProviderFuture.get()
-            }, ContextCompat.getMainExecutor(context))
-        }
-    }
-
-    // カメラの再バインド処理（プレビューモードからの復帰時も含む）
-    LaunchedEffect(cameraSelector, flashMode, cameraRebindTrigger) {
-        if (cameraProvider != null && previewView != null && !isPreviewMode) {
-            Log.d(
-                "CameraScreen",
-                "Rebinding camera - Selector: ${if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) "BACK" else "FRONT"}, Flash: $flashMode, Trigger: $cameraRebindTrigger"
-            )
-
-            try {
-                // 既存のバインディングを解除
-                cameraProvider!!.unbindAll()
-
-                // 新しいプレビューとImageCaptureを作成
-                val preview = Preview.Builder().build()
-                val newImageCapture = ImageCapture.Builder()
-                    .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)
-                    .setFlashMode(flashMode)
-                    .build()
-
-                // SurfaceProviderを設定
-                preview.surfaceProvider = previewView!!.surfaceProvider
-
-                // カメラをバインド
-                val newCamera = cameraProvider!!.bindToLifecycle(
-                    lifecycleOwner,
-                    cameraSelector,
-                    preview,
-                    newImageCapture
-                )
-
-                imageCapture = newImageCapture
-                camera = newCamera
-                viewModel.setCamera(newCamera)
-
-                Log.d("CameraScreen", "Camera rebound successfully")
-            } catch (e: Exception) {
-                Log.e("CameraScreen", "Failed to rebind camera", e)
-            }
-        }
-    }
-
-    // クリーンアップ
-    DisposableEffect(Unit) {
-        onDispose {
-            cameraProvider?.unbindAll()
         }
     }
 
@@ -194,7 +137,6 @@ fun CameraScreen(
         ) {
             if (hasCameraPermission) {
                 if (isPreviewMode && lastCapturedImageUri != null) {
-                    // 写真プレビューモード
                     Box(modifier = Modifier.fillMaxSize()) {
                         AsyncImage(
                             model = lastCapturedImageUri!!,
@@ -224,7 +166,7 @@ fun CameraScreen(
                         }
                     }
                 } else {
-                    // カメラプレビューモード
+                    // AndroidViewの改善（元のコードの構造を保持）
                     AndroidView(
                         factory = { ctx ->
                             PreviewView(ctx).apply {
@@ -232,14 +174,73 @@ fun CameraScreen(
                                     ViewGroup.LayoutParams.MATCH_PARENT,
                                     ViewGroup.LayoutParams.MATCH_PARENT
                                 )
-                                previewView = this
-                                Log.d("CameraScreen", "PreviewView created")
+                                previewView = this // PreviewViewの参照を保存
                             }
                         },
                         modifier = Modifier.fillMaxSize()
-                    )
+                    ) { view ->
+                        // 初回のみカメラプロバイダーを初期化
+                        if (cameraProvider == null) {
+                            val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+                            cameraProviderFuture.addListener({
+                                cameraProvider = cameraProviderFuture.get()
 
-                    // コントロールUI
+                                // プレビューを一度だけ作成してSurfaceProviderを設定
+                                preview = Preview.Builder().build().also {
+                                    it.setSurfaceProvider(view.surfaceProvider)
+                                }
+
+                                // 初回バインド
+                                bindCameraWithPreview(
+                                    lifecycleOwner = lifecycleOwner,
+                                    cameraProvider = cameraProvider!!,
+                                    preview = preview!!,
+                                    cameraSelector = cameraSelector,
+                                    flashMode = flashMode,
+                                    onImageCaptureCreated = { capture ->
+                                        imageCapture = capture
+                                    },
+                                    onCameraCreated = { cam ->
+                                        camera = cam
+                                        viewModel.setCamera(cam)
+                                    }
+                                )
+                            }, ContextCompat.getMainExecutor(context))
+                        }
+                    }
+
+                    // 状態変更の監視と賢い再バインド
+                    LaunchedEffect(cameraSelector, flashMode, needsCameraRebind) {
+                        // カメラプロバイダーとプレビューが準備できている場合のみ再バインド
+                        if (cameraProvider != null && preview != null) {
+                            Log.d("CameraScreen", "Rebinding camera - Selector: ${if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) "BACK" else "FRONT"}, Flash: $flashMode, NeedsRebind: $needsCameraRebind")
+
+                            // needsCameraRebindがtrueの場合は、新しいPreviewを作成
+                            if (needsCameraRebind && previewView != null) {
+                                Log.d("CameraScreen", "Creating new Preview for rebind")
+                                preview = Preview.Builder().build().also {
+                                    it.setSurfaceProvider(previewView!!.surfaceProvider)
+                                }
+                                viewModel.onCameraRebound() // フラグをリセット
+                            }
+
+                            bindCameraWithPreview(
+                                lifecycleOwner = lifecycleOwner,
+                                cameraProvider = cameraProvider!!,
+                                preview = preview!!, // 新しいまたは既存のプレビューを使用
+                                cameraSelector = cameraSelector,
+                                flashMode = flashMode,
+                                onImageCaptureCreated = { capture ->
+                                    imageCapture = capture
+                                },
+                                onCameraCreated = { cam ->
+                                    camera = cam
+                                    viewModel.setCamera(cam)
+                                }
+                            )
+                        }
+                    }
+
                     Row(
                         modifier = Modifier
                             .align(Alignment.BottomStart)
@@ -321,5 +322,47 @@ fun CameraScreen(
                 }
             }
         }
+    }
+}
+
+// 既存のPreviewを再利用するバインド関数
+private fun bindCameraWithPreview(
+    lifecycleOwner: LifecycleOwner,
+    cameraProvider: ProcessCameraProvider,
+    preview: Preview, // 既存のPreviewを受け取る
+    cameraSelector: CameraSelector,
+    flashMode: Int,
+    onImageCaptureCreated: (ImageCapture) -> Unit,
+    onCameraCreated: (Camera) -> Unit
+): Camera? {
+    return try {
+        Log.d("CameraBinding", "Binding camera with flash mode: $flashMode, camera: ${if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) "BACK" else "FRONT"}")
+
+        // ImageCaptureのみ新しく作成（フラッシュモードを反映）
+        val imageCapture = ImageCapture.Builder()
+            .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)
+            .setFlashMode(flashMode)
+            .build()
+
+        // 既存のバインディングを解除
+        cameraProvider.unbindAll()
+
+        // 既存のPreviewと新しいImageCaptureでバインド
+        val camera = cameraProvider.bindToLifecycle(
+            lifecycleOwner,
+            cameraSelector,
+            preview, // 既存のPreviewを再利用
+            imageCapture
+        )
+
+        onImageCaptureCreated(imageCapture)
+        onCameraCreated(camera)
+
+        Log.d("CameraBinding", "Camera bound successfully")
+
+        camera
+    } catch (e: Exception) {
+        Log.e("CameraBinding", "カメラのバインドに失敗しました", e)
+        null
     }
 }

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -34,6 +34,10 @@ class CameraViewModel : ViewModel() {
     private val _zoomRatio = MutableStateFlow(1.0f)
     val zoomRatio: StateFlow<Float> = _zoomRatio.asStateFlow()
 
+    // カメラ再初期化トリガー用の状態を追加
+    private val _cameraRebindTrigger = MutableStateFlow(0)
+    val cameraRebindTrigger: StateFlow<Int> = _cameraRebindTrigger.asStateFlow()
+
     private var _camera: Camera? = null
 
     fun setCamera(camera: Camera?) {
@@ -113,11 +117,15 @@ class CameraViewModel : ViewModel() {
 
     fun exitPreviewMode() {
         _isPreviewMode.value = false
-        _cameraSelector.value = _cameraSelector.value
+        // カメラ再バインドを強制的にトリガー
+        _cameraRebindTrigger.value = _cameraRebindTrigger.value + 1
+        Log.d("CameraViewModel", "Exiting preview mode, triggering camera rebind")
     }
 
     fun clearLastCapturedImage() {
         _lastCapturedImageUri.value = null
         _isPreviewMode.value = false
+        // カメラ再バインドを強制的にトリガー
+        _cameraRebindTrigger.value = _cameraRebindTrigger.value + 1
     }
-} 
+}

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -34,9 +34,9 @@ class CameraViewModel : ViewModel() {
     private val _zoomRatio = MutableStateFlow(1.0f)
     val zoomRatio: StateFlow<Float> = _zoomRatio.asStateFlow()
 
-    // カメラ再初期化トリガー用の状態を追加
-    private val _cameraRebindTrigger = MutableStateFlow(0)
-    val cameraRebindTrigger: StateFlow<Int> = _cameraRebindTrigger.asStateFlow()
+    // カメラ再初期化フラグを追加
+    private val _needsCameraRebind = MutableStateFlow(false)
+    val needsCameraRebind: StateFlow<Boolean> = _needsCameraRebind.asStateFlow()
 
     private var _camera: Camera? = null
 
@@ -117,15 +117,20 @@ class CameraViewModel : ViewModel() {
 
     fun exitPreviewMode() {
         _isPreviewMode.value = false
-        // カメラ再バインドを強制的にトリガー
-        _cameraRebindTrigger.value = _cameraRebindTrigger.value + 1
-        Log.d("CameraViewModel", "Exiting preview mode, triggering camera rebind")
+        // カメラ再バインドフラグを設定
+        _needsCameraRebind.value = true
+        Log.d("CameraViewModel", "Exiting preview mode, requesting camera rebind")
     }
 
     fun clearLastCapturedImage() {
         _lastCapturedImageUri.value = null
         _isPreviewMode.value = false
-        // カメラ再バインドを強制的にトリガー
-        _cameraRebindTrigger.value = _cameraRebindTrigger.value + 1
+        // カメラ再バインドフラグを設定
+        _needsCameraRebind.value = true
+    }
+
+    fun onCameraRebound() {
+        // カメラが再バインドされたらフラグをリセット
+        _needsCameraRebind.value = false
     }
 }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path
+        name="external_files"
+        path="." />
+    <external-files-path
+        name="external_files"
+        path="." />
+    <files-path
+        name="files"
+        path="." />
+    <cache-path
+        name="cache"
+        path="." />
+</paths> 


### PR DESCRIPTION
<html><head></head><body><h2>vtuberCameraアプリの問題修正まとめ</h2>
<h3>🔴 <strong>発生した問題</strong></h3>
<p>写真プレビューからカメラプレビューに戻ると、カメラプレビューが真っ黒になってしまう</p>
<h3>🔍 <strong>問題の原因分析</strong></h3>
<p>元のコードで発見された問題点：</p>
<ol>
<li>
<p><strong>ViewModelの<code>exitPreviewMode()</code>に問題</strong></p>
<pre><code class="language-kotlin">fun exitPreviewMode() {
    _isPreviewMode.value = false
    _cameraSelector.value = _cameraSelector.value  // ←問題：値が変わらないため再バインドされない
}
</code></pre>
</li>
<li>
<p><strong>CameraXのSurfaceProvider状態管理の問題</strong></p>
<ul>
<li>写真プレビュー表示中にAndroidViewのPreviewViewが非表示</li>
<li>戻る際にSurfaceProviderが適切に復元されていない</li>
</ul>
</li>
<li>
<p><strong>LaunchedEffectの監視対象</strong></p>
<ul>
<li><code>isPreviewMode</code>の変更を監視していたが、プレビューモードからの復帰時に確実にカメラ再バインドがトリガーされていない</li>
</ul>
</li>
</ol>
<h3>⚠️ <strong>最初の修正の問題</strong></h3>
<p>カメラの初期化ロジックを大幅に変更したため、アプリ起動時にカメラが起動しなくなった</p>
<h3>✅ <strong>最終的な解決策</strong></h3>
<h4><strong>CameraViewModel.kt の変更</strong></h4>
<pre><code class="language-kotlin">// 追加
private val _needsCameraRebind = MutableStateFlow(false)
val needsCameraRebind: StateFlow&lt;Boolean&gt; = _needsCameraRebind.asStateFlow()

// 修正
fun exitPreviewMode() {
    _isPreviewMode.value = false
    _needsCameraRebind.value = true  // カメラ再バインドフラグを設定
    Log.d("CameraViewModel", "Exiting preview mode, requesting camera rebind")
}

fun clearLastCapturedImage() {
    _lastCapturedImageUri.value = null
    _isPreviewMode.value = false
    _needsCameraRebind.value = true  // カメラ再バインドフラグを設定
}

// 追加
fun onCameraRebound() {
    _needsCameraRebind.value = false  // フラグをリセット
}
</code></pre>
<h4><strong>CameraScreen.kt の変更</strong></h4>
<pre><code class="language-kotlin">// StateFlowの監視を追加
val needsCameraRebind by viewModel.needsCameraRebind.collectAsStateWithLifecycle()

// LaunchedEffectの修正
LaunchedEffect(cameraSelector, flashMode, needsCameraRebind) {
    if (cameraProvider != null &amp;&amp; preview != null) {
        // needsCameraRebindがtrueの場合は、新しいPreviewを作成
        if (needsCameraRebind &amp;&amp; previewView != null) {
            Log.d("CameraScreen", "Creating new Preview for rebind")
            preview = Preview.Builder().build().also {
                it.setSurfaceProvider(previewView!!.surfaceProvider)
            }
            viewModel.onCameraRebound() // フラグをリセット
        }
        
        bindCameraWithPreview(/* ... */)
    }
}
</code></pre>
<h3>📋 <strong>変更のポイント</strong></h3>

項目 | 変更前 | 変更後
-- | -- | --
プレビューモード復帰 | _cameraSelector.value = _cameraSelector.valueで強制更新 | needsCameraRebindフラグで明示的に管理
カメラ初期化 | 元のロジックを保持 | 元のロジックを保持（変更なし）
SurfaceProvider | 既存のPreviewを再利用 | needsCameraRebind時のみ新しいPreviewを作成
状態管理 | StateFlowの値の強制変更 | 専用のフラグによる明示的な制御


<h3>🎯 <strong>解決された問題</strong></h3>
<p>✅ <strong>アプリ起動時のカメラ起動</strong> - 元のロジックを保持することで正常動作<br>
✅ <strong>写真プレビューからの復帰</strong> - <code>needsCameraRebind</code>フラグで確実に新しいPreviewを作成<br>
✅ <strong>カメラ切り替え</strong> - 既存のロジックで正常動作<br>
✅ <strong>フラッシュモード変更</strong> - 既存のロジックで正常動作</p>
<h3>🔧 <strong>実装における教訓</strong></h3>
<ol>
<li><strong>最小限の変更原則</strong>: 既存の動作コードはできるだけ保持し、問題部分のみを修正</li>
<li><strong>明示的な状態管理</strong>: 暗黙的な状態変更より明示的なフラグ管理が安全</li>
<li><strong>段階的な修正</strong>: 大幅な変更よりも段階的な修正でリスクを最小化</li>
<li><strong>ログ出力の重要性</strong>: デバッグ用のログ出力で問題の特定が容易になる</li>
</ol>
<p>この修正により、CameraXを使用したカメラアプリでよくある「プレビューからの復帰時の黒画面問題」が解決され、安定したカメラ動作が実現されました。</p></body></html>