### PR TITLE
test: verify switch camera icon displayed

### DIFF
--- a/app/src/androidTest/java/com/example/vtubercamera/ui/screens/CameraScreenIconTest.kt
+++ b/app/src/androidTest/java/com/example/vtubercamera/ui/screens/CameraScreenIconTest.kt
@@ -1,0 +1,25 @@
+package com.example.vtubercamera.ui.screens
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.assertIsDisplayed
+import com.example.vtubercamera.R
+import org.junit.Rule
+import org.junit.Test
+
+class CameraScreenIconTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun switchCameraIcon_isDisplayed() {
+        composeTestRule.setContent {
+            CameraScreen()
+        }
+
+        val description = composeTestRule.activity.getString(R.string.switch_camera)
+        composeTestRule.onNodeWithContentDescription(description).assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Summary
- add a Compose UI test to ensure the switch camera icon is visible on the camera screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca2d38aa0833088b418747337c901