### PR TITLE
Enable continuous pinch zoom updates

### DIFF
--- a/app/src/main/java/com/example/vtubercamera/ui/modifiers/ModernCameraGestures.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/modifiers/ModernCameraGestures.kt
@@ -40,10 +40,6 @@ fun Modifier.modernCameraGestures(
     val view = LocalView.current
     var lastZoom by remember { mutableFloatStateOf(currentZoom) }
 
-    // 外部からズーム値が更新された場合に同期する
-    LaunchedEffect(currentZoom) {
-        lastZoom = currentZoom
-    }
 
     return this
         // ピンチズーム検出
@@ -98,11 +94,6 @@ fun Modifier.advancedCameraGestures(
 ): Modifier {
     val view = LocalView.current
     var lastZoom by remember { mutableFloatStateOf(currentZoom) }
-
-    // 外部からズーム値が更新された場合に同期する
-    LaunchedEffect(currentZoom) {
-        lastZoom = currentZoom
-    }
 
     return this
         // ピンチズーム検出

--- a/app/src/main/java/com/example/vtubercamera/ui/modifiers/ModernCameraGestures.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/modifiers/ModernCameraGestures.kt
@@ -5,10 +5,10 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -38,7 +38,12 @@ fun Modifier.modernCameraGestures(
     zoomSensitivity: Float = 1.0f
 ): Modifier {
     val view = LocalView.current
-    val lastZoom = rememberUpdatedState(currentZoom)
+    var lastZoom by remember { mutableFloatStateOf(currentZoom) }
+
+    // 外部からズーム値が更新された場合に同期する
+    LaunchedEffect(currentZoom) {
+        lastZoom = currentZoom
+    }
 
     return this
         // ピンチズーム検出
@@ -48,11 +53,11 @@ fun Modifier.modernCameraGestures(
             ) { _, _, zoom, _ ->
                 // ズーム感度を適用
                 val adjustedZoom = 1f + (zoom - 1f) * zoomSensitivity
-                val newZoom = (lastZoom.value * adjustedZoom).coerceIn(minZoom, maxZoom)
+                val newZoom = (lastZoom * adjustedZoom).coerceIn(minZoom, maxZoom)
 
                 // ハプティックフィードバック（最小/最大ズーム時）
                 if (enableHapticFeedback) {
-                    val wasAtLimit = lastZoom.value == minZoom || lastZoom.value == maxZoom
+                    val wasAtLimit = lastZoom == minZoom || lastZoom == maxZoom
                     val isAtLimit = newZoom == minZoom || newZoom == maxZoom
 
                     if (isAtLimit && !wasAtLimit) {
@@ -60,6 +65,7 @@ fun Modifier.modernCameraGestures(
                     }
                 }
                 
+                lastZoom = newZoom
                 onScale(newZoom)
             }
         }
@@ -93,6 +99,11 @@ fun Modifier.advancedCameraGestures(
     val view = LocalView.current
     var lastZoom by remember { mutableFloatStateOf(currentZoom) }
 
+    // 外部からズーム値が更新された場合に同期する
+    LaunchedEffect(currentZoom) {
+        lastZoom = currentZoom
+    }
+
     return this
         // ピンチズーム検出
         .pointerInput(currentZoom, minZoom, maxZoom) {
@@ -100,7 +111,7 @@ fun Modifier.advancedCameraGestures(
                 panZoomLock = false
             ) { _, _, zoom, _ ->
                 val adjustedZoom = 1f + (zoom - 1f) * zoomSensitivity
-                val newZoom = (currentZoom * adjustedZoom).coerceIn(minZoom, maxZoom)
+                val newZoom = (lastZoom * adjustedZoom).coerceIn(minZoom, maxZoom)
 
                 if (enableHapticFeedback) {
                     val wasAtLimit = lastZoom == minZoom || lastZoom == maxZoom

--- a/app/src/main/java/com/example/vtubercamera/ui/modifiers/ModernCameraGestures.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/modifiers/ModernCameraGestures.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalView
 import kotlin.math.abs
+import kotlin.math.min
 
 /**
  * Modern camera gestures using Compose's built-in gesture detection
@@ -38,8 +39,6 @@ fun Modifier.modernCameraGestures(
     zoomSensitivity: Float = 1.0f
 ): Modifier {
     val view = LocalView.current
-    var lastZoom by remember { mutableFloatStateOf(currentZoom) }
-
 
     return this
         // ピンチズーム検出
@@ -49,19 +48,17 @@ fun Modifier.modernCameraGestures(
             ) { _, _, zoom, _ ->
                 // ズーム感度を適用
                 val adjustedZoom = 1f + (zoom - 1f) * zoomSensitivity
-                val newZoom = (lastZoom * adjustedZoom).coerceIn(minZoom, maxZoom)
+                val newZoom = (currentZoom * adjustedZoom).coerceIn(minZoom, maxZoom)
 
                 // ハプティックフィードバック（最小/最大ズーム時）
                 if (enableHapticFeedback) {
-                    val wasAtLimit = lastZoom == minZoom || lastZoom == maxZoom
+                    val wasAtLimit = currentZoom == minZoom || currentZoom == maxZoom
                     val isAtLimit = newZoom == minZoom || newZoom == maxZoom
 
                     if (isAtLimit && !wasAtLimit) {
                         view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK)
                     }
                 }
-                
-                lastZoom = newZoom
                 onScale(newZoom)
             }
         }

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -75,6 +75,7 @@ import com.example.vtubercamera.ui.components.AsyncImage
 import com.example.vtubercamera.ui.modifiers.modernCameraGestures
 import com.example.vtubercamera.ui.viewmodels.CameraViewModel
 import com.example.vtubercamera.utils.PermissionUtils
+import kotlin.math.max
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -88,6 +89,8 @@ fun CameraScreen(
     val isPreviewMode by viewModel.isPreviewMode.collectAsStateWithLifecycle()
     val flashMode by viewModel.flashMode.collectAsStateWithLifecycle()
     val zoomRatio by viewModel.zoomRatio.collectAsStateWithLifecycle()
+    val maxZoomRatio by viewModel.maxZoomRatio.collectAsStateWithLifecycle()
+    val minZoomRatio by viewModel.minZoomRatio.collectAsStateWithLifecycle()
     val needsCameraRebind by viewModel.needsCameraRebind.collectAsStateWithLifecycle()
 
     // カメラ状態管理の改善
@@ -278,6 +281,10 @@ fun CameraScreen(
                 }
 
                 else -> {
+                    viewModel.apply{
+                        setMaxZoomRatio(camera?.cameraInfo?.zoomState?.value?.maxZoomRatio ?: 10.0f)
+                        setMinZoomRatio(camera?.cameraInfo?.zoomState?.value?.minZoomRatio ?: 1.0f)
+                    }
                     if (isPreviewMode && lastCapturedImageUri != null) {
                         Box(modifier = Modifier.fillMaxSize()) {
                             AsyncImage(
@@ -335,16 +342,14 @@ fun CameraScreen(
                                     .fillMaxSize()
                                     .modernCameraGestures(
                                         onScale = { newZoom ->
-                                            viewModel.setZoom(newZoom)
+                                            viewModel.smoothZoomTo(targetZoom = newZoom, duration = 0)
                                         },
                                         onDoubleTap = {
                                             viewModel.resetZoom()
                                         },
                                         currentZoom = zoomRatio,
-                                        minZoom = camera?.cameraInfo?.zoomState?.value?.minZoomRatio
-                                            ?: 1.0f,
-                                        maxZoom = camera?.cameraInfo?.zoomState?.value?.maxZoomRatio
-                                            ?: 10.0f,
+                                        minZoom = minZoomRatio,
+                                        maxZoom = maxZoomRatio,
                                         enableHapticFeedback = true,
                                         zoomSensitivity = 2.4f
                                     )
@@ -426,10 +431,6 @@ fun CameraScreen(
                                     )
                                     .padding(horizontal = 12.dp, vertical = 8.dp)
                             ) {
-                                val maxZoomRatio =
-                                    camera?.cameraInfo?.zoomState?.value?.maxZoomRatio ?: 10.0f
-                                val minZoomRatio =
-                                    camera?.cameraInfo?.zoomState?.value?.minZoomRatio ?: 1.0f
                                 Text(
                                     text = stringResource(
                                         R.string.zoom_info,

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -14,11 +14,9 @@ import androidx.core.content.ContextCompat
 import android.animation.ValueAnimator
 import android.view.animation.DecelerateInterpolator
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -38,6 +36,12 @@ class CameraViewModel : ViewModel() {
 
     private val _zoomRatio = MutableStateFlow(1.0f)
     val zoomRatio: StateFlow<Float> = _zoomRatio.asStateFlow()
+
+    private val _maxZoomRatio = MutableStateFlow(10.0f)
+    val maxZoomRatio: StateFlow<Float> = _maxZoomRatio.asStateFlow()
+    private val _minZoomRatio = MutableStateFlow(1.0f)
+    val minZoomRatio: StateFlow<Float> = _minZoomRatio.asStateFlow()
+
 
     // カメラ再初期化フラグを追加
     private val _needsCameraRebind = MutableStateFlow(false)
@@ -85,6 +89,13 @@ class CameraViewModel : ViewModel() {
     
     fun resetZoom() {
         smoothZoomTo(1.0f)
+    }
+
+    fun setMaxZoomRatio(maxZoomRatio: Float) {
+        _maxZoomRatio.value = maxZoomRatio
+    }
+    fun setMinZoomRatio(minZoomRatio: Float) {
+        _minZoomRatio.value = minZoomRatio
     }
 
     fun takePhoto(


### PR DESCRIPTION
## Summary
- update gesture modifiers to adjust zoom continuously during pinch gestures
- keep internal zoom state in sync with external changes via `LaunchedEffect`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a550cb5ff4833084f801acf67fbf30