### PR TITLE
docs: add implementation specification to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,21 @@
 
 </div>
 
+## 📝 仕様書（現行実装）
+
+### 概要
+Jetpack Compose を用いた Android 向けカメラアプリ。CameraX によるリアルタイムプレビューと写真撮影を提供し、Android 15 向け機能や国際化にも対応しています。
+
+### アーキテクチャ
+- **MainActivity**: Android 15 機能の初期化後、`CameraScreen` を表示するエントリポイント
+- **CameraScreen**: カメラプレビューや権限確認、撮影・プレビュー UI を Compose で実装
+- **CameraViewModel**: `StateFlow` でカメラ状態を管理し、ズーム・フラッシュ・撮影などのロジックを提供
+- **Utility / Component**
+  - 権限管理 (`PermissionUtils`)
+  - Android 15 対応機能 (`Android15Features`)
+  - 画像表示 (`AsyncImage`)
+- **テーマ**: Material Design 3・動的カラー・ダークモード対応
+
 ## 📸 スクリーンショット
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@
 
 </div>
 
+## 📝 Specification (Current Implementation)
+
+### Overview
+Jetpack Compose-based Android camera app providing real-time preview and photo capture, with Android 15 features and internationalization.
+
+### Architecture
+- **MainActivity** – Initializes Android 15 capabilities and displays `CameraScreen`.
+- **CameraScreen** – Compose UI handling permission checks, preview, capture, and photo review.
+- **CameraViewModel** – Manages camera state via `StateFlow`, including zoom, flash, and capture logic.
+- **Utilities / Components**
+  - Permission management (`PermissionUtils`)
+  - Android 15 feature utilities (`Android15Features`)
+  - Image display (`AsyncImage`)
+- **Theme** – Material Design 3 with dynamic color and dark mode.
+
 ## 📸 Screenshots
 
 <div align="center">


### PR DESCRIPTION
## Summary
- document current implementation architecture and features in the English README
- add equivalent specification section to the Japanese README
- remove duplicate feature and dependency descriptions from specification sections

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a553579a448330b97ffc146db30433