### PR TITLE
feat: tap to focus on camera preview

### DIFF
--- a/app/src/main/java/com/example/vtubercamera/ui/modifiers/ModernCameraGestures.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/modifiers/ModernCameraGestures.kt
@@ -32,6 +32,7 @@ import kotlin.math.min
 fun Modifier.modernCameraGestures(
     onScale: (Float) -> Unit,
     onDoubleTap: () -> Unit = {},
+    onTap: (Offset) -> Unit = {},
     currentZoom: Float,
     minZoom: Float = 1.0f,
     maxZoom: Float = 10.0f,
@@ -65,6 +66,7 @@ fun Modifier.modernCameraGestures(
         // ダブルタップ検出
         .pointerInput(Unit) {
             detectTapGestures(
+                onTap = { offset -> onTap(offset) },
                 onDoubleTap = { onDoubleTap() }
             )
         }

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -14,6 +14,7 @@ import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,8 +23,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Camera
@@ -86,6 +89,7 @@ fun CameraScreen(
     val maxZoomRatio by viewModel.maxZoomRatio.collectAsStateWithLifecycle()
     val minZoomRatio by viewModel.minZoomRatio.collectAsStateWithLifecycle()
     val needsCameraRebind by viewModel.needsCameraRebind.collectAsStateWithLifecycle()
+    val focusPoint by viewModel.focusPoint.collectAsStateWithLifecycle()
 
     // カメラ状態管理の改善
     var imageCapture: ImageCapture? by remember { mutableStateOf(null) }
@@ -348,6 +352,34 @@ fun CameraScreen(
                                             }
                                         )
                                     }, ContextCompat.getMainExecutor(context))
+                                }
+                            }
+
+                            // フォーカスポイントの円を表示
+                            focusPoint?.let { (x, y) ->
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(0.dp)
+                                ) {
+                                    Box(
+                                        modifier = Modifier
+                                            .size(10.dp)
+                                            .align(Alignment.TopStart)
+                                            .offset(
+                                                x = ((x - 5f).dp).coerceAtLeast(0.dp),
+                                                y = ((y - 5f).dp).coerceAtLeast(0.dp)
+                                            )
+                                            .background(
+                                                color = Color.White,
+                                                shape = CircleShape
+                                            )
+                                            .border(
+                                                width = 1.dp,
+                                                color = Color.Black,
+                                                shape = CircleShape
+                                            )
+                                    )
                                 }
                             }
 

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -310,6 +310,9 @@ fun CameraScreen(
                                         onDoubleTap = {
                                             viewModel.resetZoom()
                                         },
+                                        onTap = { offset ->
+                                            previewView?.let { viewModel.focusOnPoint(it, offset.x, offset.y) }
+                                        },
                                         currentZoom = zoomRatio,
                                         minZoom = minZoomRatio,
                                         maxZoom = maxZoomRatio,

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -15,10 +15,13 @@ import androidx.core.content.ContextCompat
 import android.animation.ValueAnimator
 import android.view.animation.DecelerateInterpolator
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.camera.view.PreviewView
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -48,6 +51,10 @@ class CameraViewModel : ViewModel() {
     // カメラ再初期化フラグを追加
     private val _needsCameraRebind = MutableStateFlow(false)
     val needsCameraRebind: StateFlow<Boolean> = _needsCameraRebind.asStateFlow()
+
+    // フォーカスポイントの状態管理
+    private val _focusPoint = MutableStateFlow<Pair<Float, Float>?>(null)
+    val focusPoint: StateFlow<Pair<Float, Float>?> = _focusPoint.asStateFlow()
 
     private var _camera: Camera? = null
 
@@ -98,6 +105,13 @@ class CameraViewModel : ViewModel() {
         val point = factory.createPoint(x, y)
         val action = FocusMeteringAction.Builder(point).build()
         _camera?.cameraControl?.startFocusAndMetering(action)
+        
+        // フォーカスポイントを設定し、1秒後に消す
+        _focusPoint.value = Pair(x, y)
+        viewModelScope.launch {
+            delay(1000) // 1秒待機
+            _focusPoint.value = null
+        }
     }
 
     fun setMaxZoomRatio(maxZoomRatio: Float) {

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -8,12 +8,14 @@ import android.provider.MediaStore
 import android.util.Log
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
+import androidx.camera.core.FocusMeteringAction
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCaptureException
 import androidx.core.content.ContextCompat
 import android.animation.ValueAnimator
 import android.view.animation.DecelerateInterpolator
 import androidx.lifecycle.ViewModel
+import androidx.camera.view.PreviewView
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -89,6 +91,13 @@ class CameraViewModel : ViewModel() {
     
     fun resetZoom() {
         smoothZoomTo(1.0f)
+    }
+
+    fun focusOnPoint(previewView: PreviewView, x: Float, y: Float) {
+        val factory = previewView.meteringPointFactory
+        val point = factory.createPoint(x, y)
+        val action = FocusMeteringAction.Builder(point).build()
+        _camera?.cameraControl?.startFocusAndMetering(action)
     }
 
     fun setMaxZoomRatio(maxZoomRatio: Float) {


### PR DESCRIPTION
## Summary
- allow single tap on preview to focus at touched location
- expose a tap callback in `modernCameraGestures`
- add focus control helper in `CameraViewModel`

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a7ad982ae88330ac357aa99b0906af