### PR TITLE
Add gallery support for viewing all device photos

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.vtubercamera"
-        minSdk 24
+        minSdk 25
         targetSdk 36
         versionCode 1
         versionName "1.0"
@@ -55,6 +55,7 @@ android {
 
 dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-android:2.9.2'
+    implementation 'androidx.wear.compose:compose-material3:1.5.0'
     def camerax_version = "1.4.2"
     def compose_version = "1.7.8"
 

--- a/app/src/main/java/com/example/vtubercamera/ui/components/CommonDialogs.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/components/CommonDialogs.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import android.widget.Toast
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -98,7 +97,7 @@ fun DeleteConfirmDialog(
 @Preview(locale = "ja")
 @Preview(locale = "en")
 @Composable
-fun DeleteConfirmDialogPreview(){
+fun DeleteConfirmDialogPreview() {
     DeleteConfirmDialog(
         onDismiss = {},
         onConfirm = {}
@@ -108,7 +107,7 @@ fun DeleteConfirmDialogPreview(){
 @Preview(locale = "ja")
 @Preview(locale = "en")
 @Composable
-fun PartialAccessDialogPreview(){
+fun PartialAccessDialogPreview() {
     PartialAccessDialog(
         onDismiss = {},
         context = androidx.compose.ui.platform.LocalContext.current

--- a/app/src/main/java/com/example/vtubercamera/ui/components/GalleryComponents.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/components/GalleryComponents.kt
@@ -1,0 +1,158 @@
+package com.example.vtubercamera.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.vtubercamera.ui.viewmodels.PhotoItem
+
+@Composable
+fun GalleryView(
+    photos: List<PhotoItem>,
+    isLoading: Boolean,
+    selectedPhotos: Set<android.net.Uri>,
+    isSelectionMode: Boolean,
+    onPhotoClick: (PhotoItem) -> Unit,
+    onPhotoLongClick: (PhotoItem) -> Unit
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        when {
+            isLoading -> LoadingIndicator(
+                modifier = Modifier.align(Alignment.Center)
+            )
+            photos.isEmpty() -> EmptyGalleryMessage(
+                modifier = Modifier.align(Alignment.Center)
+            )
+            else -> PhotoGrid(
+                photos = photos,
+                selectedPhotos = selectedPhotos,
+                isSelectionMode = isSelectionMode,
+                onPhotoClick = onPhotoClick,
+                onPhotoLongClick = onPhotoLongClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingIndicator(modifier: Modifier = Modifier) {
+    CircularProgressIndicator(modifier = modifier)
+}
+
+@Composable
+private fun EmptyGalleryMessage(modifier: Modifier = Modifier) {
+    Text(
+        text = "写真がありません",
+        modifier = modifier,
+        style = MaterialTheme.typography.bodyLarge
+    )
+}
+
+@Composable
+private fun PhotoGrid(
+    photos: List<PhotoItem>,
+    selectedPhotos: Set<android.net.Uri>,
+    isSelectionMode: Boolean,
+    onPhotoClick: (PhotoItem) -> Unit,
+    onPhotoLongClick: (PhotoItem) -> Unit
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        contentPadding = PaddingValues(4.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        items(photos) { photo ->
+            PhotoGridItem(
+                photo = photo,
+                isSelected = selectedPhotos.contains(photo.uri),
+                isSelectionMode = isSelectionMode,
+                onPhotoClick = onPhotoClick,
+                onPhotoLongClick = onPhotoLongClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotoGridItem(
+    photo: PhotoItem,
+    isSelected: Boolean,
+    isSelectionMode: Boolean,
+    onPhotoClick: (PhotoItem) -> Unit,
+    onPhotoLongClick: (PhotoItem) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .aspectRatio(1f)
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onLongPress = { onPhotoLongClick(photo) },
+                    onTap = { onPhotoClick(photo) }
+                )
+            }
+    ) {
+        PhotoImage(photo = photo)
+        
+        if (isSelectionMode) {
+            SelectionOverlay(isSelected = isSelected)
+            SelectionIcon(
+                isSelected = isSelected,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+                    .size(24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotoImage(photo: PhotoItem) {
+    AsyncImage(
+        model = photo.uri,
+        contentDescription = photo.displayName,
+        modifier = Modifier.fillMaxSize(),
+        contentScale = ContentScale.Crop
+    )
+}
+
+@Composable
+private fun SelectionOverlay(isSelected: Boolean) {
+    if (isSelected) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Blue.copy(alpha = 0.3f))
+        )
+    }
+}
+
+@Composable
+private fun SelectionIcon(isSelected: Boolean, modifier: Modifier = Modifier) {
+    Icon(
+        imageVector = if (isSelected) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+        contentDescription = if (isSelected) "選択済み" else "未選択",
+        tint = if (isSelected) Color.Blue else Color.White,
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/example/vtubercamera/ui/components/PhotoDetailComponent.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/components/PhotoDetailComponent.kt
@@ -1,0 +1,151 @@
+package com.example.vtubercamera.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.vtubercamera.ui.viewmodels.PhotoItem
+
+@Composable
+fun PhotoDetailView(
+    photo: PhotoItem,
+    onBack: () -> Unit,
+    onDelete: (PhotoItem) -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    hasNext: Boolean,
+    hasPrevious: Boolean
+) {
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("写真を削除") },
+            text = { Text("この写真を削除しますか？") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDelete(photo)
+                        showDeleteDialog = false
+                    }
+                ) {
+                    Text("削除")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("キャンセル")
+                }
+            }
+        )
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        PhotoImage(photo = photo)
+        TopActionBar(onBack = onBack, onDelete = { showDeleteDialog = true })
+        NavigationButtons(
+            hasNext = hasNext,
+            hasPrevious = hasPrevious,
+            onNext = onNext,
+            onPrevious = onPrevious,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(16.dp)
+        )
+    }
+}
+
+@Composable
+private fun PhotoImage(photo: PhotoItem) {
+    AsyncImage(
+        model = photo.uri,
+        contentDescription = photo.displayName,
+        modifier = Modifier.fillMaxSize(),
+        contentScale = ContentScale.Fit
+    )
+}
+
+@Composable
+private fun TopActionBar(
+    onBack: () -> Unit,
+    onDelete: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .background(
+                color = Color.Black.copy(alpha = 0.5f),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "戻る",
+                tint = Color.White
+            )
+        }
+
+        IconButton(onClick = onDelete) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = "削除",
+                tint = Color.White
+            )
+        }
+    }
+}
+
+@Composable
+private fun NavigationButtons(
+    hasNext: Boolean,
+    hasPrevious: Boolean,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        if (hasPrevious) {
+            FloatingActionButton(
+                onClick = onPrevious,
+                modifier = Modifier.size(48.dp)
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "前の写真"
+                )
+            }
+        }
+
+        if (hasNext) {
+            FloatingActionButton(
+                onClick = onNext,
+                modifier = Modifier.size(48.dp)
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowForward,
+                    contentDescription = "次の写真"
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/vtubercamera/ui/components/PhotoDetailComponent.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/components/PhotoDetailComponent.kt
@@ -13,8 +13,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.example.vtubercamera.R
 import com.example.vtubercamera.ui.viewmodels.PhotoItem
 
 @Composable
@@ -32,8 +35,8 @@ fun PhotoDetailView(
     if (showDeleteDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
-            title = { Text("写真を削除") },
-            text = { Text("この写真を削除しますか？") },
+            title = { Text(stringResource(R.string.delete_photo_title)) },
+            text = { Text(stringResource(R.string.delete_photo_confirmation)) },
             confirmButton = {
                 TextButton(
                     onClick = {
@@ -41,12 +44,12 @@ fun PhotoDetailView(
                         showDeleteDialog = false
                     }
                 ) {
-                    Text("削除")
+                    Text(stringResource(R.string.delete))
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showDeleteDialog = false }) {
-                    Text("キャンセル")
+                    Text(stringResource(R.string.cancel))
                 }
             }
         )
@@ -97,7 +100,7 @@ private fun TopActionBar(
         IconButton(onClick = onBack) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "戻る",
+                contentDescription = stringResource(R.string.back),
                 tint = Color.White
             )
         }
@@ -105,7 +108,7 @@ private fun TopActionBar(
         IconButton(onClick = onDelete) {
             Icon(
                 imageVector = Icons.Default.Delete,
-                contentDescription = "削除",
+                contentDescription = stringResource(R.string.delete),
                 tint = Color.White
             )
         }
@@ -124,28 +127,28 @@ private fun NavigationButtons(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        if (hasPrevious) {
-            FloatingActionButton(
-                onClick = onPrevious,
-                modifier = Modifier.size(48.dp)
-            ) {
-                Icon(
-                    Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "前の写真"
-                )
+            if (hasPrevious) {
+                FloatingActionButton(
+                    onClick = onPrevious,
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.previous_photo)
+                    )
+                }
             }
-        }
 
-        if (hasNext) {
-            FloatingActionButton(
-                onClick = onNext,
-                modifier = Modifier.size(48.dp)
-            ) {
-                Icon(
-                    Icons.AutoMirrored.Filled.ArrowForward,
-                    contentDescription = "次の写真"
-                )
+            if (hasNext) {
+                FloatingActionButton(
+                    onClick = onNext,
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowForward,
+                        contentDescription = stringResource(R.string.next_photo)
+                    )
+                }
             }
-        }
     }
 }

--- a/app/src/main/java/com/example/vtubercamera/ui/components/PhotoPreviewComponent.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/components/PhotoPreviewComponent.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.vtubercamera.R
-import com.example.vtubercamera.ui.components.AsyncImage
 
 @Composable
 fun PhotoPreviewComponent(

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -369,11 +369,12 @@ fun CameraScreen(
                         setMinZoomRatio(camera?.cameraInfo?.zoomState?.value?.minZoomRatio ?: 1.0f)
                     }
 
+                    val currentOrientation = LocalConfiguration.current.orientation
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
                             .graphicsLayer {
-                                rotationZ = when (context.resources.configuration.orientation) {
+                                rotationZ = when (currentOrientation) {
                                     Configuration.ORIENTATION_LANDSCAPE -> 90f
                                     else -> 0f
                                 }

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -18,10 +18,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -36,8 +32,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -50,9 +46,10 @@ import com.example.vtubercamera.BuildConfig
 import com.example.vtubercamera.R
 import com.example.vtubercamera.ui.components.AsyncImage
 import com.example.vtubercamera.ui.components.DeleteConfirmDialog
+import com.example.vtubercamera.ui.components.GalleryView
 import com.example.vtubercamera.ui.components.PartialAccessDialog
-import com.example.vtubercamera.ui.components.PhotoPreviewComponent
 import com.example.vtubercamera.ui.components.PermissionRequestComponent
+import com.example.vtubercamera.ui.components.PhotoPreviewComponent
 import com.example.vtubercamera.ui.modifiers.modernCameraGestures
 import com.example.vtubercamera.ui.viewmodels.CameraViewModel
 import com.example.vtubercamera.ui.viewmodels.PhotoItem
@@ -65,7 +62,7 @@ fun CameraScreen(
 ) {
     val context = LocalContext.current
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
-    
+
     // デバイス設定の読み取り
     val configuration = LocalConfiguration.current
     val language = configuration.locales[0].language
@@ -425,7 +422,7 @@ fun CameraScreen(
                                 }, ContextCompat.getMainExecutor(context))
                             }
                         }
-                        
+
                         // 設定情報のデバッグ表示
                         if (BuildConfig.DEBUG) {
                             ConfigurationDebugPanel(
@@ -544,104 +541,32 @@ fun CameraScreen(
                                 contentDescription = stringResource(R.string.take_photo)
                             )
                         }
-                            // 最後に撮影した写真のサムネイル
-                            lastCapturedImageUri?.let { uri ->
-                                Box(
-                                    modifier = Modifier
-                                        .align(Alignment.BottomEnd)
-                                        .padding(16.dp)
-                                        .size(80.dp)
-                                        .clip(RoundedCornerShape(8.dp))
-                                        .pointerInput(Unit) {
-                                            detectTapGestures(
-                                                onLongPress = {
-                                                    showDeleteConfirmDialog = true
-                                                },
-                                                onTap = {
-                                                    viewModel.enterPreviewMode()
-                                                }
-                                            )
-                                        }
-                                ) {
-                                    AsyncImage(
-                                        model = uri,
-                                        contentDescription = stringResource(R.string.last_captured_photo),
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentScale = ContentScale.Crop
-                                    )
-                                }
-                            }
-                    }
-                    }
-                }
-            }
-        }
-    }
-@Composable
-private fun GalleryView(
-    photos: List<PhotoItem>,
-    isLoading: Boolean,
-    selectedPhotos: Set<android.net.Uri>,
-    isSelectionMode: Boolean,
-    onPhotoClick: (PhotoItem) -> Unit,
-    onPhotoLongClick: (PhotoItem) -> Unit
-) {
-    Box(modifier = Modifier.fillMaxSize()) {
-        if (isLoading) {
-            CircularProgressIndicator(
-                modifier = Modifier.align(Alignment.Center)
-            )
-        } else if (photos.isEmpty()) {
-            Text(
-                text = "写真がありません",
-                modifier = Modifier.align(Alignment.Center),
-                style = MaterialTheme.typography.bodyLarge
-            )
-        } else {
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(3),
-                contentPadding = PaddingValues(4.dp),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-                horizontalArrangement = Arrangement.spacedBy(2.dp)
-            ) {
-                items(photos.size) { index ->
-                    val photo = photos[index]
-                    val isSelected = selectedPhotos.contains(photo.uri)
-
-                    Box(
-                        modifier = Modifier
-                            .aspectRatio(1f)
-                            .pointerInput(Unit) {
-                                detectTapGestures(
-                                    onLongPress = { onPhotoLongClick(photo) },
-                                    onTap = { onPhotoClick(photo) }
-                                )
-                            }
-                    ) {
-                        AsyncImage(
-                            model = photo.uri,
-                            contentDescription = photo.displayName,
-                            modifier = Modifier.fillMaxSize(),
-                            contentScale = ContentScale.Crop
-                        )
-
-                        if (isSelectionMode) {
-                            if (isSelected) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .background(Color.Blue.copy(alpha = 0.3f))
-                                )
-                            }
-                            Icon(
-                                imageVector = if (isSelected) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
-                                contentDescription = if (isSelected) "選択済み" else "未選択",
-                                tint = if (isSelected) Color.Blue else Color.White,
+                        // 最後に撮影した写真のサムネイル
+                        lastCapturedImageUri?.let { uri ->
+                            Box(
                                 modifier = Modifier
-                                    .align(Alignment.TopEnd)
-                                    .padding(8.dp)
-                                    .size(24.dp)
-                            )
+                                    .align(Alignment.BottomEnd)
+                                    .padding(16.dp)
+                                    .size(80.dp)
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .pointerInput(Unit) {
+                                        detectTapGestures(
+                                            onLongPress = {
+                                                showDeleteConfirmDialog = true
+                                            },
+                                            onTap = {
+                                                viewModel.enterPreviewMode()
+                                            }
+                                        )
+                                    }
+                            ) {
+                                AsyncImage(
+                                    model = uri,
+                                    contentDescription = stringResource(R.string.last_captured_photo),
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentScale = ContentScale.Crop
+                                )
+                            }
                         }
                     }
                 }
@@ -649,6 +574,7 @@ private fun GalleryView(
         }
     }
 }
+
 
 @Composable
 private fun PhotoDetailView(

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -16,33 +16,17 @@ import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Camera
-import androidx.compose.material.icons.filled.Cameraswitch
-import androidx.compose.material.icons.filled.FlashAuto
-import androidx.compose.material.icons.filled.FlashOff
-import androidx.compose.material.icons.filled.FlashOn
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -66,6 +50,7 @@ import com.example.vtubercamera.ui.components.PermissionRequestComponent
 import com.example.vtubercamera.ui.components.PhotoPreviewComponent
 import com.example.vtubercamera.ui.modifiers.modernCameraGestures
 import com.example.vtubercamera.ui.viewmodels.CameraViewModel
+import com.example.vtubercamera.ui.viewmodels.PhotoItem
 import com.example.vtubercamera.utils.PermissionUtils
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -84,8 +69,12 @@ fun CameraScreen(
     val minZoomRatio by viewModel.minZoomRatio.collectAsStateWithLifecycle()
     val needsCameraRebind by viewModel.needsCameraRebind.collectAsStateWithLifecycle()
     val focusPoint by viewModel.focusPoint.collectAsStateWithLifecycle()
+    val allPhotos by viewModel.allPhotos.collectAsStateWithLifecycle()
+    val isLoadingPhotos by viewModel.isLoadingPhotos.collectAsStateWithLifecycle()
+    val selectedPhotos by viewModel.selectedPhotos.collectAsStateWithLifecycle()
+    val isSelectionMode by viewModel.isSelectionMode.collectAsStateWithLifecycle()
+    val currentViewingPhoto by viewModel.currentViewingPhoto.collectAsStateWithLifecycle()
 
-    // カメラ状態管理の改善
     var imageCapture: ImageCapture? by remember { mutableStateOf(null) }
     var camera: Camera? by remember { mutableStateOf(null) }
     var cameraProvider: ProcessCameraProvider? by remember { mutableStateOf(null) }
@@ -93,6 +82,7 @@ fun CameraScreen(
     var preview: Preview? by remember { mutableStateOf(null) }
     var showPartialAccessDialog by remember { mutableStateOf(false) }
     var showDeleteConfirmDialog by remember { mutableStateOf(false) }
+    var showGalleryView by remember { mutableStateOf(false) }
 
     var hasCameraPermission by remember {
         mutableStateOf(
@@ -105,20 +95,16 @@ fun CameraScreen(
         )
     }
 
-    // カメラ権限リクエスト用ランチャー
     val cameraPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
         onResult = { granted ->
             hasCameraPermission = granted
         }
     )
-    // メディアアクセス権限リクエスト用ランチャー
     val mediaPermissionsLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions(),
         onResult = { permissions ->
             hasMediaPermissions = permissions.values.all { it }
-
-            // Android 15: パーシャルアクセスの確認
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                 val hasPartialAccess = PermissionUtils.hasPartialMediaAccess(context)
                 if (hasPartialAccess && !permissions[Manifest.permission.READ_MEDIA_IMAGES]!!) {
@@ -128,7 +114,6 @@ fun CameraScreen(
         }
     )
 
-    // 初期権限チェック
     LaunchedEffect(Unit) {
         if (!hasCameraPermission) {
             cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
@@ -138,7 +123,12 @@ fun CameraScreen(
         }
     }
 
-    // パーシャルアクセスダイアログ（Android 15対応）
+    LaunchedEffect(hasMediaPermissions) {
+        if (hasMediaPermissions) {
+            viewModel.loadAllPhotos(context)
+        }
+    }
+
     if (showPartialAccessDialog) {
         PartialAccessDialog(
             onDismiss = { showPartialAccessDialog = false },
@@ -146,53 +136,114 @@ fun CameraScreen(
         )
     }
 
-    // 削除確認ダイアログ
     if (showDeleteConfirmDialog) {
         DeleteConfirmDialog(
             onDismiss = { showDeleteConfirmDialog = false },
             onConfirm = {
-                lastCapturedImageUri?.let { uri ->
-                    val success = viewModel.deletePhoto(context, uri)
-                    if (success) {
-                        Toast.makeText(
-                            context,
-                            R.string.photo_deleted_successfully,
-                            Toast.LENGTH_SHORT
-                        ).show()
-                        viewModel.clearLastCapturedImage(context)
-                    } else {
-                        Toast.makeText(
-                            context,
-                            R.string.photo_deletion_failed,
-                            Toast.LENGTH_SHORT
-                        ).show()
+                if (isSelectionMode && selectedPhotos.isNotEmpty()) {
+                    val deletedCount = viewModel.deleteSelectedPhotos(context)
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.photos_deleted_count, deletedCount),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                } else {
+                    lastCapturedImageUri?.let { uri ->
+                        val success = viewModel.deletePhoto(context, uri)
+                        if (success) {
+                            Toast.makeText(
+                                context,
+                                R.string.photo_deleted_successfully,
+                                Toast.LENGTH_SHORT
+                            ).show()
+                            viewModel.clearLastCapturedImage(context)
+                        } else {
+                            Toast.makeText(
+                                context,
+                                R.string.photo_deletion_failed,
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
                     }
                 }
+                showDeleteConfirmDialog = false
             }
         )
     }
 
-
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.camera_title)) },
-                actions = {
-                    IconButton(onClick = { viewModel.toggleFlash() }) {
-                        Icon(
-                            imageVector = when (flashMode) {
-                                ImageCapture.FLASH_MODE_ON -> Icons.Default.FlashOn
-                                ImageCapture.FLASH_MODE_AUTO -> Icons.Default.FlashAuto
-                                else -> Icons.Default.FlashOff
-                            },
-                            contentDescription = stringResource(R.string.flash_mode_toggle)
-                        )
+                title = {
+                    Text(
+                        if (showGalleryView) "ギャラリー" else stringResource(R.string.camera_title)
+                    )
+                },
+                navigationIcon = {
+                    if (showGalleryView) {
+                        IconButton(onClick = {
+                            showGalleryView = false
+                            viewModel.exitSelectionMode()
+                        }) {
+                            Icon(
+                                imageVector = Icons.Default.ArrowBack,
+                                contentDescription = "戻る"
+                            )
+                        }
                     }
-                    IconButton(onClick = { viewModel.switchCamera() }) {
-                        Icon(
-                            imageVector = Icons.Default.Cameraswitch,
-                            contentDescription = stringResource(R.string.switch_camera)
-                        )
+                },
+                actions = {
+                    if (showGalleryView) {
+                        if (isSelectionMode) {
+                            IconButton(onClick = { viewModel.toggleSelectAll() }) {
+                                Icon(
+                                    imageVector = if (selectedPhotos.size == allPhotos.size && allPhotos.isNotEmpty())
+                                        Icons.Default.SelectAll else Icons.Default.CheckBox,
+                                    contentDescription = "全選択"
+                                )
+                            }
+                            IconButton(
+                                onClick = { showDeleteConfirmDialog = true },
+                                enabled = selectedPhotos.isNotEmpty()
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Delete,
+                                    contentDescription = "削除"
+                                )
+                            }
+                        } else {
+                            IconButton(onClick = { viewModel.startSelectionMode() }) {
+                                Icon(
+                                    imageVector = Icons.Default.SelectAll,
+                                    contentDescription = "選択"
+                                )
+                            }
+                        }
+                    } else {
+                        if (allPhotos.isNotEmpty()) {
+                            IconButton(onClick = { showGalleryView = true }) {
+                                Icon(
+                                    imageVector = Icons.Default.Photo,
+                                    contentDescription = "ギャラリー"
+                                )
+                            }
+                        }
+                        IconButton(onClick = { viewModel.toggleFlash() }) {
+                            Icon(
+                                imageVector = when (flashMode) {
+                                    ImageCapture.FLASH_MODE_ON -> Icons.Default.FlashOn
+                                    ImageCapture.FLASH_MODE_AUTO -> Icons.Default.FlashAuto
+                                    else -> Icons.Default.FlashOff
+                                },
+                                contentDescription = stringResource(R.string.flash_mode_toggle)
+                            )
+                        }
+                        IconButton(onClick = { viewModel.switchCamera() }) {
+                            Icon(
+                                imageVector = Icons.Default.Cameraswitch,
+                                contentDescription = stringResource(R.string.switch_camera)
+                            )
+                        }
                     }
                 }
             )
@@ -222,152 +273,123 @@ fun CameraScreen(
                     )
                 }
 
+                currentViewingPhoto != null -> {
+                    PhotoDetailView(
+                        photo = currentViewingPhoto!!,
+                        onBack = { viewModel.setCurrentViewingPhoto(null) },
+                        onDelete = { photo ->
+                            val success = viewModel.deletePhoto(context, photo.uri)
+                            if (success) {
+                                Toast.makeText(context, "写真を削除しました", Toast.LENGTH_SHORT).show()
+                                viewModel.setCurrentViewingPhoto(null)
+                            }
+                        },
+                        onNext = { viewModel.goToNextPhoto() },
+                        onPrevious = { viewModel.goToPreviousPhoto() },
+                        hasNext = allPhotos.isNotEmpty() &&
+                                allPhotos.indexOfFirst { it.id == currentViewingPhoto!!.id } < allPhotos.size - 1,
+                        hasPrevious = allPhotos.isNotEmpty() &&
+                                allPhotos.indexOfFirst { it.id == currentViewingPhoto!!.id } > 0
+                    )
+                }
+
+                showGalleryView -> {
+                    GalleryView(
+                        photos = allPhotos,
+                        isLoading = isLoadingPhotos,
+                        selectedPhotos = selectedPhotos,
+                        isSelectionMode = isSelectionMode,
+                        onPhotoClick = { photo ->
+                            if (isSelectionMode) {
+                                viewModel.togglePhotoSelection(photo.uri)
+                            } else {
+                                viewModel.setCurrentViewingPhoto(photo)
+                            }
+                        },
+                        onPhotoLongClick = { photo ->
+                            if (!isSelectionMode) {
+                                viewModel.startSelectionMode()
+                                viewModel.togglePhotoSelection(photo.uri)
+                            }
+                        }
+                    )
+                }
+
+                isPreviewMode -> {
+                    PhotoPreviewComponent(
+                        imageUri = lastCapturedImageUri.toString(),
+                        onDelete = { showDeleteConfirmDialog = true },
+                        onBack = { viewModel.exitPreviewMode() }
+                    )
+                }
+
                 else -> {
                     viewModel.apply {
                         setMaxZoomRatio(camera?.cameraInfo?.zoomState?.value?.maxZoomRatio ?: 10.0f)
                         setMinZoomRatio(camera?.cameraInfo?.zoomState?.value?.minZoomRatio ?: 1.0f)
                     }
-                    if (isPreviewMode) {
-                        PhotoPreviewComponent(
-                            imageUri = lastCapturedImageUri.toString(),
-                            onDelete = { showDeleteConfirmDialog = true },
-                            onBack = { viewModel.exitPreviewMode() }
-                        )
 
-                    } else {
-                        // カメラプレビューとコントロールを回転可能なBoxでラップ
-                        Box(
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .graphicsLayer {
+                                rotationZ = when (context.resources.configuration.orientation) {
+                                    android.content.res.Configuration.ORIENTATION_LANDSCAPE -> 90f
+                                    else -> 0f
+                                }
+                            }
+                    ) {
+                        AndroidView(
+                            factory = { ctx ->
+                                PreviewView(ctx).apply {
+                                    layoutParams = ViewGroup.LayoutParams(
+                                        ViewGroup.LayoutParams.MATCH_PARENT,
+                                        ViewGroup.LayoutParams.MATCH_PARENT
+                                    )
+                                    previewView = this
+                                }
+                            },
                             modifier = Modifier
                                 .fillMaxSize()
-                                .graphicsLayer {
-                                    // 画面の向きに応じて回転
-                                    rotationZ = when (context.resources.configuration.orientation) {
-                                        android.content.res.Configuration.ORIENTATION_LANDSCAPE -> 90f
-                                        else -> 0f
-                                    }
-                                }
-                        ) {
-                            // AndroidViewの改善（元のコードの構造を保持）
-                            AndroidView(
-                                factory = { ctx ->
-                                    PreviewView(ctx).apply {
-                                        layoutParams = ViewGroup.LayoutParams(
-                                            ViewGroup.LayoutParams.MATCH_PARENT,
-                                            ViewGroup.LayoutParams.MATCH_PARENT
+                                .modernCameraGestures(
+                                    onScale = { newZoom ->
+                                        viewModel.smoothZoomTo(
+                                            targetZoom = newZoom,
+                                            duration = 0
                                         )
-                                        previewView = this // PreviewViewの参照を保存
-                                    }
-                                },
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .modernCameraGestures(
-                                        onScale = { newZoom ->
-                                            viewModel.smoothZoomTo(
-                                                targetZoom = newZoom,
-                                                duration = 0
+                                    },
+                                    onDoubleTap = {
+                                        viewModel.resetZoom()
+                                    },
+                                    onTap = { offset ->
+                                        previewView?.let {
+                                            viewModel.focusOnPoint(
+                                                it,
+                                                offset.x,
+                                                offset.y
                                             )
-                                        },
-                                        onDoubleTap = {
-                                            viewModel.resetZoom()
-                                        },
-                                        onTap = { offset ->
-                                            previewView?.let {
-                                                viewModel.focusOnPoint(
-                                                    it,
-                                                    offset.x,
-                                                    offset.y
-                                                )
-                                            }
-                                        },
-                                        currentZoom = zoomRatio,
-                                        minZoom = minZoomRatio,
-                                        maxZoom = maxZoomRatio,
-                                        enableHapticFeedback = true,
-                                        zoomSensitivity = 2.4f
-                                    )
-                            ) { view ->
-                                // 初回のみカメラプロバイダーを初期化
-                                if (cameraProvider == null) {
-                                    val cameraProviderFuture =
-                                        ProcessCameraProvider.getInstance(context)
-                                    cameraProviderFuture.addListener({
-                                        cameraProvider = cameraProviderFuture.get()
-
-                                        // プレビューを一度だけ作成してSurfaceProviderを設定
-                                        preview = Preview.Builder().build().also {
-                                            it.surfaceProvider = view.surfaceProvider
                                         }
+                                    },
+                                    currentZoom = zoomRatio,
+                                    minZoom = minZoomRatio,
+                                    maxZoom = maxZoomRatio,
+                                    enableHapticFeedback = true,
+                                    zoomSensitivity = 2.4f
+                                )
+                        ) { view ->
+                            if (cameraProvider == null) {
+                                val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+                                cameraProviderFuture.addListener({
+                                    cameraProvider = cameraProviderFuture.get()
 
-                                        // 初回バインド
-                                        bindCameraWithPreview(
-                                            lifecycleOwner = lifecycleOwner,
-                                            cameraProvider = cameraProvider!!,
-                                            preview = preview!!,
-                                            cameraSelector = cameraSelector,
-                                            flashMode = flashMode,
-                                            initialZoomRatio = zoomRatio,
-                                            onImageCaptureCreated = { capture ->
-                                                imageCapture = capture
-                                            },
-                                            onCameraCreated = { cam ->
-                                                camera = cam
-                                                viewModel.setCamera(cam)
-                                            }
-                                        )
-                                    }, ContextCompat.getMainExecutor(context))
-                                }
-                            }
-
-                            // フォーカスポイントの円を表示
-                            focusPoint?.let { (x, y) ->
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .padding(0.dp)
-                                ) {
-                                    Box(
-                                        modifier = Modifier
-                                            .size(10.dp)
-                                            .align(Alignment.TopStart)
-                                            .offset(
-                                                x = ((x - 5f).dp).coerceAtLeast(0.dp),
-                                                y = ((y - 5f).dp).coerceAtLeast(0.dp)
-                                            )
-                                            .background(
-                                                color = Color.White,
-                                                shape = CircleShape
-                                            )
-                                            .border(
-                                                width = 1.dp,
-                                                color = Color.Black,
-                                                shape = CircleShape
-                                            )
-                                    )
-                                }
-                            }
-
-                            // 状態変更の監視と賢い再バインド
-                            LaunchedEffect(cameraSelector,  needsCameraRebind) {
-                                // カメラプロバイダーとプレビューが準備できている場合のみ再バインド
-                                if (cameraProvider != null && preview != null) {
-                                    Log.d(
-                                        "CameraScreen",
-                                        "Rebinding camera - Selector: ${if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) "BACK" else "FRONT"}, Flash: $flashMode, NeedsRebind: $needsCameraRebind"
-                                    )
-
-                                    // needsCameraRebindがtrueの場合は、新しいPreviewを作成
-                                    if (needsCameraRebind && previewView != null) {
-                                        Log.d("CameraScreen", "Creating new Preview for rebind")
-                                        preview = Preview.Builder().build().also {
-                                            it.surfaceProvider = previewView!!.surfaceProvider
-                                        }
-                                        viewModel.onCameraRebound() // フラグをリセット
+                                    preview = Preview.Builder().build().also {
+                                        it.surfaceProvider = view.surfaceProvider
                                     }
 
                                     bindCameraWithPreview(
                                         lifecycleOwner = lifecycleOwner,
                                         cameraProvider = cameraProvider!!,
-                                        preview = preview!!, // 新しいまたは既存のプレビューを使用
+                                        preview = preview!!,
                                         cameraSelector = cameraSelector,
                                         flashMode = flashMode,
                                         initialZoomRatio = zoomRatio,
@@ -379,81 +401,189 @@ fun CameraScreen(
                                             viewModel.setCamera(cam)
                                         }
                                     )
-                                }
+                                }, ContextCompat.getMainExecutor(context))
                             }
+                        }
 
-                            // ズーム情報表示
+                        focusPoint?.let { (x, y) ->
                             Box(
                                 modifier = Modifier
-                                    .align(Alignment.TopEnd)
-                                    .padding(16.dp)
-                                    .background(
-                                        color = Color.Black.copy(alpha = 0.5f),
-                                        shape = RoundedCornerShape(8.dp)
-                                    )
-                                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                                    .fillMaxSize()
+                                    .padding(0.dp)
                             ) {
-                                Text(
-                                    text = stringResource(
-                                        R.string.zoom_info,
-                                        zoomRatio, minZoomRatio, maxZoomRatio
-                                    ),
-                                    color = Color.White,
-                                    style = MaterialTheme.typography.bodySmall
-                                )
-                            }
-                            // シャッターボタン
-                            FloatingActionButton(
-                                onClick = {
-                                    imageCapture?.let { capture ->
-                                        viewModel.takePhoto(
-                                            imageCapture = capture,
-                                            context = context,
-                                            onPhotoSaved = { /* トーストメッセージを削除 */ },
-                                            onError = { msg ->
-                                                Toast.makeText(context, msg, Toast.LENGTH_SHORT)
-                                                    .show()
-                                            }
-                                        )
-                                    }
-                                },
-                                modifier = Modifier
-                                    .align(Alignment.BottomCenter)
-                                    .padding(bottom = 16.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Camera,
-                                    contentDescription = stringResource(R.string.take_photo)
-                                )
-                            }
-
-                            // 最後に撮影した写真のサムネイル
-                            lastCapturedImageUri?.let { uri ->
                                 Box(
                                     modifier = Modifier
-                                        .align(Alignment.BottomEnd)
-                                        .padding(16.dp)
-                                        .size(80.dp)
-                                        .clip(RoundedCornerShape(8.dp))
-                                        .pointerInput(Unit) {
-                                            detectTapGestures(
-                                                onLongPress = {
-                                                    showDeleteConfirmDialog = true
-                                                },
-                                                onTap = {
-                                                    viewModel.enterPreviewMode()
-                                                }
-                                            )
+                                        .size(10.dp)
+                                        .align(Alignment.TopStart)
+                                        .offset(
+                                            x = ((x - 5f).dp).coerceAtLeast(0.dp),
+                                            y = ((y - 5f).dp).coerceAtLeast(0.dp)
+                                        )
+                                        .background(
+                                            color = Color.White,
+                                            shape = CircleShape
+                                        )
+                                        .border(
+                                            width = 1.dp,
+                                            color = Color.Black,
+                                            shape = CircleShape
+                                        )
+                                )
+                            }
+                        }
+
+                        LaunchedEffect(cameraSelector, needsCameraRebind) {
+                            if (cameraProvider != null && preview != null) {
+                                Log.d(
+                                    "CameraScreen",
+                                    "Rebinding camera - Selector: ${if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) "BACK" else "FRONT"}, Flash: $flashMode, NeedsRebind: $needsCameraRebind"
+                                )
+
+                                if (needsCameraRebind && previewView != null) {
+                                    Log.d("CameraScreen", "Creating new Preview for rebind")
+                                    preview = Preview.Builder().build().also {
+                                        it.surfaceProvider = previewView!!.surfaceProvider
+                                    }
+                                    viewModel.onCameraRebound()
+                                }
+
+                                bindCameraWithPreview(
+                                    lifecycleOwner = lifecycleOwner,
+                                    cameraProvider = cameraProvider!!,
+                                    preview = preview!!,
+                                    cameraSelector = cameraSelector,
+                                    flashMode = flashMode,
+                                    initialZoomRatio = zoomRatio,
+                                    onImageCaptureCreated = { capture ->
+                                        imageCapture = capture
+                                    },
+                                    onCameraCreated = { cam ->
+                                        camera = cam
+                                        viewModel.setCamera(cam)
+                                    }
+                                )
+                            }
+                        }
+
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(16.dp)
+                                .background(
+                                    color = Color.Black.copy(alpha = 0.5f),
+                                    shape = RoundedCornerShape(8.dp)
+                                )
+                                .padding(horizontal = 12.dp, vertical = 8.dp)
+                        ) {
+                            Text(
+                                text = stringResource(
+                                    R.string.zoom_info,
+                                    zoomRatio, minZoomRatio, maxZoomRatio
+                                ),
+                                color = Color.White,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+
+                        FloatingActionButton(
+                            onClick = {
+                                imageCapture?.let { capture ->
+                                    viewModel.takePhoto(
+                                        imageCapture = capture,
+                                        context = context,
+                                        onPhotoSaved = { },
+                                        onError = { msg ->
+                                            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
                                         }
-                                ) {
-                                    AsyncImage(
-                                        model = uri,
-                                        contentDescription = stringResource(R.string.last_captured_photo),
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentScale = ContentScale.Crop
                                     )
                                 }
-                            }
+                            },
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(bottom = 16.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Camera,
+                                contentDescription = stringResource(R.string.take_photo)
+                            )
+                        }
+
+                        PhotoPreviewArea(
+                            lastCapturedImageUri = lastCapturedImageUri,
+                            recentPhotos = allPhotos.take(5),
+                            onLastPhotoClick = { viewModel.enterPreviewMode() },
+                            onLastPhotoLongPress = { showDeleteConfirmDialog = true },
+                            onRecentPhotoClick = { photo ->
+                                viewModel.setCurrentViewingPhoto(photo)
+                            },
+                            modifier = Modifier
+                                .align(Alignment.BottomStart)
+                                .padding(16.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PhotoPreviewArea(
+    lastCapturedImageUri: android.net.Uri?,
+    recentPhotos: List<PhotoItem>,
+    onLastPhotoClick: () -> Unit,
+    onLastPhotoLongPress: () -> Unit,
+    onRecentPhotoClick: (PhotoItem) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (lastCapturedImageUri != null || recentPhotos.isNotEmpty()) {
+        Column(modifier = modifier) {
+            lastCapturedImageUri?.let { uri ->
+                Box(
+                    modifier = Modifier
+                        .size(80.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .pointerInput(Unit) {
+                            detectTapGestures(
+                                onLongPress = { onLastPhotoLongPress() },
+                                onTap = { onLastPhotoClick() }
+                            )
+                        }
+                ) {
+                    AsyncImage(
+                        model = uri,
+                        contentDescription = "最後に撮影した写真",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+
+                if (recentPhotos.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+
+            if (recentPhotos.isNotEmpty()) {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    items(recentPhotos) { photo ->
+                        Box(
+                            modifier = Modifier
+                                .size(50.dp)
+                                .clip(RoundedCornerShape(6.dp))
+                                .pointerInput(Unit) {
+                                    detectTapGestures {
+                                        onRecentPhotoClick(photo)
+                                    }
+                                }
+                        ) {
+                            AsyncImage(
+                                model = photo.uri,
+                                contentDescription = "最近の写真",
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Crop
+                            )
                         }
                     }
                 }
@@ -462,11 +592,182 @@ fun CameraScreen(
     }
 }
 
-// 既存のPreviewを再利用するバインド関数
+@Composable
+private fun GalleryView(
+    photos: List<PhotoItem>,
+    isLoading: Boolean,
+    selectedPhotos: Set<android.net.Uri>,
+    isSelectionMode: Boolean,
+    onPhotoClick: (PhotoItem) -> Unit,
+    onPhotoLongClick: (PhotoItem) -> Unit
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        if (isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center)
+            )
+        } else if (photos.isEmpty()) {
+            Text(
+                text = "写真がありません",
+                modifier = Modifier.align(Alignment.Center),
+                style = MaterialTheme.typography.bodyLarge
+            )
+        } else {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                contentPadding = PaddingValues(4.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+                horizontalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                items(photos.size) { index ->
+                    val photo = photos[index]
+                    val isSelected = selectedPhotos.contains(photo.uri)
+
+                    Box(
+                        modifier = Modifier
+                            .aspectRatio(1f)
+                            .pointerInput(Unit) {
+                                detectTapGestures(
+                                    onLongPress = { onPhotoLongClick(photo) },
+                                    onTap = { onPhotoClick(photo) }
+                                )
+                            }
+                    ) {
+                        AsyncImage(
+                            model = photo.uri,
+                            contentDescription = photo.displayName,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop
+                        )
+
+                        if (isSelectionMode) {
+                            if (isSelected) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .background(Color.Blue.copy(alpha = 0.3f))
+                                )
+                            }
+                            Icon(
+                                imageVector = if (isSelected) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                                contentDescription = if (isSelected) "選択済み" else "未選択",
+                                tint = if (isSelected) Color.Blue else Color.White,
+                                modifier = Modifier
+                                    .align(Alignment.TopEnd)
+                                    .padding(8.dp)
+                                    .size(24.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PhotoDetailView(
+    photo: PhotoItem,
+    onBack: () -> Unit,
+    onDelete: (PhotoItem) -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    hasNext: Boolean,
+    hasPrevious: Boolean
+) {
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("写真を削除") },
+            text = { Text("この写真を削除しますか？") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDelete(photo)
+                        showDeleteDialog = false
+                    }
+                ) {
+                    Text("削除")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("キャンセル")
+                }
+            }
+        )
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        AsyncImage(
+            model = photo.uri,
+            contentDescription = photo.displayName,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Fit
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .background(
+                    color = Color.Black.copy(alpha = 0.5f),
+                    shape = RoundedCornerShape(8.dp)
+                )
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = "戻る",
+                    tint = Color.White
+                )
+            }
+
+            IconButton(onClick = { showDeleteDialog = true }) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "削除",
+                    tint = Color.White
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            if (hasPrevious) {
+                FloatingActionButton(
+                    onClick = onPrevious,
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "前の写真")
+                }
+            }
+
+            if (hasNext) {
+                FloatingActionButton(
+                    onClick = onNext,
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    Icon(Icons.Default.ArrowForward, contentDescription = "次の写真")
+                }
+            }
+        }
+    }
+}
+
 private fun bindCameraWithPreview(
     lifecycleOwner: LifecycleOwner,
     cameraProvider: ProcessCameraProvider,
-    preview: Preview, // 既存のPreviewを受け取る
+    preview: Preview,
     cameraSelector: CameraSelector,
     flashMode: Int,
     initialZoomRatio: Float? = null,
@@ -479,27 +780,23 @@ private fun bindCameraWithPreview(
             "Binding camera with flash mode: $flashMode, camera: ${if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) "BACK" else "FRONT"}"
         )
 
-        // ImageCaptureのみ新しく作成（フラッシュモードを反映）
         val imageCapture = ImageCapture.Builder()
             .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)
             .setFlashMode(flashMode)
             .build()
 
-        // 既存のバインディングを解除
         cameraProvider.unbindAll()
 
-        // 既存のPreviewと新しいImageCaptureでバインド
         val camera = cameraProvider.bindToLifecycle(
             lifecycleOwner,
             cameraSelector,
-            preview, // 既存のPreviewを再利用
+            preview,
             imageCapture
         )
 
         onImageCaptureCreated(imageCapture)
         onCameraCreated(camera)
 
-        // 再バインドによってリセットされるズームを復元
         initialZoomRatio?.let { targetZoom ->
             try {
                 val minZoom = camera.cameraInfo.zoomState.value?.minZoomRatio ?: 1.0f
@@ -520,3 +817,4 @@ private fun bindCameraWithPreview(
         null
     }
 }
+

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -1,6 +1,7 @@
 package com.example.vtubercamera.ui.screens
 
 import android.Manifest
+import android.content.res.Configuration
 import android.os.Build
 import android.util.Log
 import android.view.ViewGroup
@@ -18,14 +19,14 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.automirrored.filled.*
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -36,6 +37,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -43,12 +46,13 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.vtubercamera.BuildConfig
 import com.example.vtubercamera.R
 import com.example.vtubercamera.ui.components.AsyncImage
 import com.example.vtubercamera.ui.components.DeleteConfirmDialog
 import com.example.vtubercamera.ui.components.PartialAccessDialog
-import com.example.vtubercamera.ui.components.PermissionRequestComponent
 import com.example.vtubercamera.ui.components.PhotoPreviewComponent
+import com.example.vtubercamera.ui.components.PermissionRequestComponent
 import com.example.vtubercamera.ui.modifiers.modernCameraGestures
 import com.example.vtubercamera.ui.viewmodels.CameraViewModel
 import com.example.vtubercamera.ui.viewmodels.PhotoItem
@@ -61,6 +65,16 @@ fun CameraScreen(
 ) {
     val context = LocalContext.current
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    
+    // デバイス設定の読み取り
+    val configuration = LocalConfiguration.current
+    val language = configuration.locales[0].language
+    val country = configuration.locales[0].country
+    val orientation = configuration.orientation
+    val density = configuration.densityDpi
+    val screenDp = LocalWindowInfo.current.containerSize
+    val uiMode = configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+    val isNightMode = uiMode == Configuration.UI_MODE_NIGHT_YES
     val cameraSelector by viewModel.cameraSelector.collectAsStateWithLifecycle()
     val lastCapturedImageUri by viewModel.lastCapturedImageUri.collectAsStateWithLifecycle()
     val isPreviewMode by viewModel.isPreviewMode.collectAsStateWithLifecycle()
@@ -145,7 +159,11 @@ fun CameraScreen(
                     val deletedCount = viewModel.deleteSelectedPhotos(context)
                     Toast.makeText(
                         context,
-                        context.resources.getQuantityString(R.plurals.photos_deleted_count, deletedCount, deletedCount),
+                        context.resources.getQuantityString(
+                            R.plurals.photos_deleted_count,
+                            deletedCount,
+                            deletedCount
+                        ),
                         Toast.LENGTH_SHORT
                     ).show()
                 } else {
@@ -281,7 +299,8 @@ fun CameraScreen(
                         onDelete = { photo ->
                             val success = viewModel.deletePhoto(context, photo.uri)
                             if (success) {
-                                Toast.makeText(context, "写真を削除しました", Toast.LENGTH_SHORT).show()
+                                Toast.makeText(context, "写真を削除しました", Toast.LENGTH_SHORT)
+                                    .show()
                                 viewModel.setCurrentViewingPhoto(null)
                             }
                         },
@@ -335,7 +354,7 @@ fun CameraScreen(
                             .fillMaxSize()
                             .graphicsLayer {
                                 rotationZ = when (context.resources.configuration.orientation) {
-                                    android.content.res.Configuration.ORIENTATION_LANDSCAPE -> 90f
+                                    Configuration.ORIENTATION_LANDSCAPE -> 90f
                                     else -> 0f
                                 }
                             }
@@ -379,7 +398,8 @@ fun CameraScreen(
                                 )
                         ) { view ->
                             if (cameraProvider == null) {
-                                val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+                                val cameraProviderFuture =
+                                    ProcessCameraProvider.getInstance(context)
                                 cameraProviderFuture.addListener({
                                     cameraProvider = cameraProviderFuture.get()
 
@@ -404,6 +424,22 @@ fun CameraScreen(
                                     )
                                 }, ContextCompat.getMainExecutor(context))
                             }
+                        }
+                        
+                        // 設定情報のデバッグ表示
+                        if (BuildConfig.DEBUG) {
+                            ConfigurationDebugPanel(
+                                language = language,
+                                country = country,
+                                orientation = orientation,
+                                density = density,
+                                screenWidthDp = screenDp.width,
+                                screenHeightDp = screenDp.height,
+                                isNightMode = isNightMode,
+                                modifier = Modifier
+                                    .align(Alignment.TopStart)
+                                    .padding(8.dp)
+                            )
                         }
 
                         focusPoint?.let { (x, y) ->
@@ -819,3 +855,57 @@ private fun bindCameraWithPreview(
     }
 }
 
+@Composable
+private fun ConfigurationDebugPanel(
+    language: String,
+    country: String,
+    orientation: Int,
+    density: Int,
+    screenWidthDp: Int,
+    screenHeightDp: Int,
+    isNightMode: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = Color.Black.copy(alpha = 0.7f)
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Text(
+                text = "設定情報",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White
+            )
+            Text(
+                text = "言語: $language-$country",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White
+            )
+            Text(
+                text = "向き: ${if (orientation == Configuration.ORIENTATION_LANDSCAPE) "横" else "縦"}",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White
+            )
+            Text(
+                text = "密度: ${density}dpi",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White
+            )
+            Text(
+                text = "画面: ${screenWidthDp}×${screenHeightDp}dp",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White
+            )
+            Text(
+                text = "テーマ: ${if (isNightMode) "ダーク" else "ライト"}",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -544,91 +544,39 @@ fun CameraScreen(
                                 contentDescription = stringResource(R.string.take_photo)
                             )
                         }
-
-                        PhotoPreviewArea(
-                            lastCapturedImageUri = lastCapturedImageUri,
-                            recentPhotos = allPhotos.take(5),
-                            onLastPhotoClick = { viewModel.enterPreviewMode() },
-                            onLastPhotoLongPress = { showDeleteConfirmDialog = true },
-                            onRecentPhotoClick = { photo ->
-                                viewModel.setCurrentViewingPhoto(photo)
-                            },
-                            modifier = Modifier
-                                .align(Alignment.BottomStart)
-                                .padding(16.dp)
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun PhotoPreviewArea(
-    lastCapturedImageUri: android.net.Uri?,
-    recentPhotos: List<PhotoItem>,
-    onLastPhotoClick: () -> Unit,
-    onLastPhotoLongPress: () -> Unit,
-    onRecentPhotoClick: (PhotoItem) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    if (lastCapturedImageUri != null || recentPhotos.isNotEmpty()) {
-        Column(modifier = modifier) {
-            lastCapturedImageUri?.let { uri ->
-                Box(
-                    modifier = Modifier
-                        .size(80.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .pointerInput(Unit) {
-                            detectTapGestures(
-                                onLongPress = { onLastPhotoLongPress() },
-                                onTap = { onLastPhotoClick() }
-                            )
-                        }
-                ) {
-                    AsyncImage(
-                        model = uri,
-                        contentDescription = "最後に撮影した写真",
-                        modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop
-                    )
-                }
-
-                if (recentPhotos.isNotEmpty()) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                }
-            }
-
-            if (recentPhotos.isNotEmpty()) {
-                LazyRow(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    items(recentPhotos) { photo ->
-                        Box(
-                            modifier = Modifier
-                                .size(50.dp)
-                                .clip(RoundedCornerShape(6.dp))
-                                .pointerInput(Unit) {
-                                    detectTapGestures {
-                                        onRecentPhotoClick(photo)
-                                    }
+                            // 最後に撮影した写真のサムネイル
+                            lastCapturedImageUri?.let { uri ->
+                                Box(
+                                    modifier = Modifier
+                                        .align(Alignment.BottomEnd)
+                                        .padding(16.dp)
+                                        .size(80.dp)
+                                        .clip(RoundedCornerShape(8.dp))
+                                        .pointerInput(Unit) {
+                                            detectTapGestures(
+                                                onLongPress = {
+                                                    showDeleteConfirmDialog = true
+                                                },
+                                                onTap = {
+                                                    viewModel.enterPreviewMode()
+                                                }
+                                            )
+                                        }
+                                ) {
+                                    AsyncImage(
+                                        model = uri,
+                                        contentDescription = stringResource(R.string.last_captured_photo),
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentScale = ContentScale.Crop
+                                    )
                                 }
-                        ) {
-                            AsyncImage(
-                                model = photo.uri,
-                                contentDescription = "最近の写真",
-                                modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop
-                            )
-                        }
+                            }
+                    }
                     }
                 }
             }
         }
     }
-}
-
 @Composable
 private fun GalleryView(
     photos: List<PhotoItem>,

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -50,6 +50,7 @@ import com.example.vtubercamera.ui.components.GalleryView
 import com.example.vtubercamera.ui.components.PartialAccessDialog
 import com.example.vtubercamera.ui.components.PermissionRequestComponent
 import com.example.vtubercamera.ui.components.PhotoPreviewComponent
+import com.example.vtubercamera.ui.components.PhotoDetailView
 import com.example.vtubercamera.ui.modifiers.modernCameraGestures
 import com.example.vtubercamera.ui.viewmodels.CameraViewModel
 import com.example.vtubercamera.ui.viewmodels.PhotoItem
@@ -576,104 +577,7 @@ fun CameraScreen(
 }
 
 
-@Composable
-private fun PhotoDetailView(
-    photo: PhotoItem,
-    onBack: () -> Unit,
-    onDelete: (PhotoItem) -> Unit,
-    onNext: () -> Unit,
-    onPrevious: () -> Unit,
-    hasNext: Boolean,
-    hasPrevious: Boolean
-) {
-    var showDeleteDialog by remember { mutableStateOf(false) }
 
-    if (showDeleteDialog) {
-        AlertDialog(
-            onDismissRequest = { showDeleteDialog = false },
-            title = { Text("写真を削除") },
-            text = { Text("この写真を削除しますか？") },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        onDelete(photo)
-                        showDeleteDialog = false
-                    }
-                ) {
-                    Text("削除")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDeleteDialog = false }) {
-                    Text("キャンセル")
-                }
-            }
-        )
-    }
-
-    Box(modifier = Modifier.fillMaxSize()) {
-        AsyncImage(
-            model = photo.uri,
-            contentDescription = photo.displayName,
-            modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.Fit
-        )
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-                .background(
-                    color = Color.Black.copy(alpha = 0.5f),
-                    shape = RoundedCornerShape(8.dp)
-                )
-                .padding(8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = onBack) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "戻る",
-                    tint = Color.White
-                )
-            }
-
-            IconButton(onClick = { showDeleteDialog = true }) {
-                Icon(
-                    imageVector = Icons.Default.Delete,
-                    contentDescription = "削除",
-                    tint = Color.White
-                )
-            }
-        }
-
-        Row(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            if (hasPrevious) {
-                FloatingActionButton(
-                    onClick = onPrevious,
-                    modifier = Modifier.size(48.dp)
-                ) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前の写真")
-                }
-            }
-
-            if (hasNext) {
-                FloatingActionButton(
-                    onClick = onNext,
-                    modifier = Modifier.size(48.dp)
-                ) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "次の写真")
-                }
-            }
-        }
-    }
-}
 
 private fun bindCameraWithPreview(
     lifecycleOwner: LifecycleOwner,

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -17,14 +17,38 @@ import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.*
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Camera
+import androidx.compose.material.icons.filled.Cameraswitch
+import androidx.compose.material.icons.filled.CheckBox
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.FlashAuto
+import androidx.compose.material.icons.filled.FlashOff
+import androidx.compose.material.icons.filled.FlashOn
+import androidx.compose.material.icons.filled.Photo
+import androidx.compose.material.icons.filled.SelectAll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,18 +66,16 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.vtubercamera.BuildConfig
 import com.example.vtubercamera.R
 import com.example.vtubercamera.ui.components.AsyncImage
 import com.example.vtubercamera.ui.components.DeleteConfirmDialog
 import com.example.vtubercamera.ui.components.GalleryView
 import com.example.vtubercamera.ui.components.PartialAccessDialog
 import com.example.vtubercamera.ui.components.PermissionRequestComponent
-import com.example.vtubercamera.ui.components.PhotoPreviewComponent
 import com.example.vtubercamera.ui.components.PhotoDetailView
+import com.example.vtubercamera.ui.components.PhotoPreviewComponent
 import com.example.vtubercamera.ui.modifiers.modernCameraGestures
 import com.example.vtubercamera.ui.viewmodels.CameraViewModel
-import com.example.vtubercamera.ui.viewmodels.PhotoItem
 import com.example.vtubercamera.utils.PermissionUtils
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -66,13 +88,13 @@ fun CameraScreen(
 
     // デバイス設定の読み取り
     val configuration = LocalConfiguration.current
-    val language = configuration.locales[0].language
-    val country = configuration.locales[0].country
-    val orientation = configuration.orientation
-    val density = configuration.densityDpi
-    val screenDp = LocalWindowInfo.current.containerSize
+    configuration.locales[0].language
+    configuration.locales[0].country
+    configuration.orientation
+    configuration.densityDpi
+    LocalWindowInfo.current.containerSize
     val uiMode = configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-    val isNightMode = uiMode == Configuration.UI_MODE_NIGHT_YES
+    uiMode == Configuration.UI_MODE_NIGHT_YES
     val cameraSelector by viewModel.cameraSelector.collectAsStateWithLifecycle()
     val lastCapturedImageUri by viewModel.lastCapturedImageUri.collectAsStateWithLifecycle()
     val isPreviewMode by viewModel.isPreviewMode.collectAsStateWithLifecycle()
@@ -424,21 +446,6 @@ fun CameraScreen(
                             }
                         }
 
-                        // 設定情報のデバッグ表示
-                        if (BuildConfig.DEBUG) {
-                            ConfigurationDebugPanel(
-                                language = language,
-                                country = country,
-                                orientation = orientation,
-                                density = density,
-                                screenWidthDp = screenDp.width,
-                                screenHeightDp = screenDp.height,
-                                isNightMode = isNightMode,
-                                modifier = Modifier
-                                    .align(Alignment.TopStart)
-                                    .padding(8.dp)
-                            )
-                        }
 
                         focusPoint?.let { (x, y) ->
                             Box(
@@ -577,8 +584,6 @@ fun CameraScreen(
 }
 
 
-
-
 private fun bindCameraWithPreview(
     lifecycleOwner: LifecycleOwner,
     cameraProvider: ProcessCameraProvider,
@@ -630,60 +635,5 @@ private fun bindCameraWithPreview(
     } catch (e: Exception) {
         Log.e("CameraBinding", "カメラのバインドに失敗しました", e)
         null
-    }
-}
-
-@Composable
-private fun ConfigurationDebugPanel(
-    language: String,
-    country: String,
-    orientation: Int,
-    density: Int,
-    screenWidthDp: Int,
-    screenHeightDp: Int,
-    isNightMode: Boolean,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = Color.Black.copy(alpha = 0.7f)
-        )
-    ) {
-        Column(
-            modifier = Modifier.padding(8.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp)
-        ) {
-            Text(
-                text = "設定情報",
-                style = MaterialTheme.typography.labelSmall,
-                color = Color.White
-            )
-            Text(
-                text = "言語: $language-$country",
-                style = MaterialTheme.typography.labelSmall,
-                color = Color.White
-            )
-            Text(
-                text = "向き: ${if (orientation == Configuration.ORIENTATION_LANDSCAPE) "横" else "縦"}",
-                style = MaterialTheme.typography.labelSmall,
-                color = Color.White
-            )
-            Text(
-                text = "密度: ${density}dpi",
-                style = MaterialTheme.typography.labelSmall,
-                color = Color.White
-            )
-            Text(
-                text = "画面: ${screenWidthDp}×${screenHeightDp}dp",
-                style = MaterialTheme.typography.labelSmall,
-                color = Color.White
-            )
-            Text(
-                text = "テーマ: ${if (isNightMode) "ダーク" else "ライト"}",
-                style = MaterialTheme.typography.labelSmall,
-                color = Color.White
-            )
-        }
     }
 }

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -144,7 +144,7 @@ fun CameraScreen(
                     val deletedCount = viewModel.deleteSelectedPhotos(context)
                     Toast.makeText(
                         context,
-                        context.getString(R.string.photos_deleted_count, deletedCount),
+                        context.resources.getQuantityString(R.plurals.photos_deleted_count, deletedCount, deletedCount),
                         Toast.LENGTH_SHORT
                     ).show()
                 } else {

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -186,7 +187,7 @@ fun CameraScreen(
                             viewModel.exitSelectionMode()
                         }) {
                             Icon(
-                                imageVector = Icons.Default.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = "戻る"
                             )
                         }
@@ -722,7 +723,7 @@ private fun PhotoDetailView(
         ) {
             IconButton(onClick = onBack) {
                 Icon(
-                    imageVector = Icons.Default.ArrowBack,
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "戻る",
                     tint = Color.White
                 )
@@ -748,7 +749,7 @@ private fun PhotoDetailView(
                     onClick = onPrevious,
                     modifier = Modifier.size(48.dp)
                 ) {
-                    Icon(Icons.Default.ArrowBack, contentDescription = "前の写真")
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前の写真")
                 }
             }
 
@@ -757,7 +758,7 @@ private fun PhotoDetailView(
                     onClick = onNext,
                     modifier = Modifier.size(48.dp)
                 ) {
-                    Icon(Icons.Default.ArrowForward, contentDescription = "次の写真")
+                    Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "次の写真")
                 }
             }
         }

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -95,6 +95,8 @@ class CameraViewModel : ViewModel() {
             CameraSelector.DEFAULT_FRONT_CAMERA -> CameraSelector.DEFAULT_BACK_CAMERA
             else -> CameraSelector.DEFAULT_BACK_CAMERA
         }
+        // カメラ切り替え時に再バインドが必要
+        _needsCameraRebind.value = true
     }
 
     fun toggleFlash() {
@@ -400,6 +402,8 @@ class CameraViewModel : ViewModel() {
     fun exitSelectionMode() {
         _isSelectionMode.value = false
         _selectedPhotos.value = emptySet()
+        // ギャラリーから戻った時にカメラを再バインド
+        _needsCameraRebind.value = true
     }
 
     /**
@@ -436,6 +440,10 @@ class CameraViewModel : ViewModel() {
      */
     fun setCurrentViewingPhoto(photo: PhotoItem?) {
         _currentViewingPhoto.value = photo
+        // 写真詳細ビューから戻った時にカメラを再バインド
+        if (photo == null) {
+            _needsCameraRebind.value = true
+        }
     }
 
     /**

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -1,29 +1,40 @@
 package com.example.vtubercamera.ui.viewmodels
 
+import android.animation.ValueAnimator
 import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.util.Log
+import android.view.animation.DecelerateInterpolator
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.FocusMeteringAction
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCaptureException
+import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
-import android.animation.ValueAnimator
-import android.view.animation.DecelerateInterpolator
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.camera.view.PreviewView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Locale
+
+data class PhotoItem(
+    val id: Long,
+    val uri: Uri,
+    val displayName: String,
+    val dateAdded: Long,
+    val size: Long,
+    val mimeType: String,
+)
 
 class CameraViewModel : ViewModel() {
 
@@ -55,6 +66,22 @@ class CameraViewModel : ViewModel() {
     // フォーカスポイントの状態管理
     private val _focusPoint = MutableStateFlow<Pair<Float, Float>?>(null)
     val focusPoint: StateFlow<Pair<Float, Float>?> = _focusPoint.asStateFlow()
+
+    // ギャラリー機能の状態管理
+    private val _allPhotos = MutableStateFlow<List<PhotoItem>>(emptyList())
+    val allPhotos: StateFlow<List<PhotoItem>> = _allPhotos.asStateFlow()
+
+    private val _isLoadingPhotos = MutableStateFlow(false)
+    val isLoadingPhotos: StateFlow<Boolean> = _isLoadingPhotos.asStateFlow()
+
+    private val _selectedPhotos = MutableStateFlow<Set<Uri>>(emptySet())
+    val selectedPhotos: StateFlow<Set<Uri>> = _selectedPhotos.asStateFlow()
+
+    private val _isSelectionMode = MutableStateFlow(false)
+    val isSelectionMode: StateFlow<Boolean> = _isSelectionMode.asStateFlow()
+
+    private val _currentViewingPhoto = MutableStateFlow<PhotoItem?>(null)
+    val currentViewingPhoto: StateFlow<PhotoItem?> = _currentViewingPhoto.asStateFlow()
 
     private var _camera: Camera? = null
 
@@ -155,6 +182,8 @@ class CameraViewModel : ViewModel() {
                     Log.d("Camera", msg)
                     _lastCapturedImageUri.value = output.savedUri
                     onPhotoSaved(msg)
+                    // 写真一覧を更新
+                    loadAllPhotos(context)
                 }
 
                 override fun onError(exc: ImageCaptureException) {
@@ -162,7 +191,7 @@ class CameraViewModel : ViewModel() {
                     Log.e("Camera", msg, exc)
                     onError(msg)
                 }
-            }
+            },
         )
     }
 
@@ -182,6 +211,8 @@ class CameraViewModel : ViewModel() {
                 try {
                     ctx.contentResolver.delete(uri, null, null)
                     Log.d("CameraViewModel", "写真を削除しました: $uri")
+                    // 写真一覧を更新
+                    loadAllPhotos(context)
                 } catch (e: Exception) {
                     Log.e("CameraViewModel", "写真の削除に失敗しました", e)
                 }
@@ -203,7 +234,7 @@ class CameraViewModel : ViewModel() {
         return try {
             val deletedRows = context.contentResolver.delete(uri, null, null)
             val success = deletedRows > 0
-            
+
             if (success) {
                 Log.d("CameraViewModel", "写真を削除しました: $uri")
                 // 削除した写真が現在表示中の写真と同じ場合は状態をクリア
@@ -212,10 +243,12 @@ class CameraViewModel : ViewModel() {
                     _isPreviewMode.value = false
                     _needsCameraRebind.value = true
                 }
+                // 写真一覧を更新
+                loadAllPhotos(context)
             } else {
                 Log.w("CameraViewModel", "写真の削除に失敗しました: $uri")
             }
-            
+
             success
         } catch (e: Exception) {
             Log.e("CameraViewModel", "写真の削除中にエラーが発生しました", e)
@@ -232,11 +265,198 @@ class CameraViewModel : ViewModel() {
     fun deleteMultiplePhotos(context: Context, uris: List<Uri>): Int {
         var successCount = 0
         uris.forEach { uri ->
-            if (deletePhoto(context, uri)) {
-                successCount++
+            try {
+                val deletedRows = context.contentResolver.delete(uri, null, null)
+                if (deletedRows > 0) {
+                    successCount++
+                }
+            } catch (e: Exception) {
+                Log.e("CameraViewModel", "写真の削除中にエラーが発生しました", e)
             }
         }
+
+        if (successCount > 0) {
+            // 写真一覧を更新
+            loadAllPhotos(context)
+            // 選択をクリア
+            clearSelection()
+        }
+
         return successCount
+    }
+
+    /**
+     * 端末内の全ての写真を取得
+     */
+    fun loadAllPhotos(context: Context) {
+        viewModelScope.launch {
+            _isLoadingPhotos.value = true
+            try {
+                val photos = withContext(Dispatchers.IO) {
+                    getAllPhotosFromDevice(context)
+                }
+                _allPhotos.value = photos
+                Log.d("CameraViewModel", "読み込んだ写真数: ${photos.size}")
+            } catch (e: Exception) {
+                Log.e("CameraViewModel", "写真の読み込みに失敗しました", e)
+                _allPhotos.value = emptyList()
+            } finally {
+                _isLoadingPhotos.value = false
+            }
+        }
+    }
+
+    /**
+     * MediaStoreから全ての写真を取得
+     */
+    private fun getAllPhotosFromDevice(context: Context): List<PhotoItem> {
+        val photos = mutableListOf<PhotoItem>()
+
+        val projection = arrayOf(
+            MediaStore.Images.Media._ID,
+            MediaStore.Images.Media.DISPLAY_NAME,
+            MediaStore.Images.Media.DATE_ADDED,
+            MediaStore.Images.Media.SIZE,
+            MediaStore.Images.Media.MIME_TYPE,
+        )
+
+        val sortOrder = "${MediaStore.Images.Media.DATE_ADDED} DESC"
+
+        try {
+            context.contentResolver.query(
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                projection,
+                null,
+                null,
+                sortOrder,
+            )?.use { cursor ->
+                val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+                val displayNameColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DISPLAY_NAME)
+                val dateAddedColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_ADDED)
+                val sizeColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.SIZE)
+                val mimeTypeColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.MIME_TYPE)
+
+                while (cursor.moveToNext()) {
+                    val id = cursor.getLong(idColumn)
+                    val displayName = cursor.getString(displayNameColumn) ?: ""
+                    val dateAdded = cursor.getLong(dateAddedColumn)
+                    val size = cursor.getLong(sizeColumn)
+                    val mimeType = cursor.getString(mimeTypeColumn) ?: ""
+
+                    val uri = Uri.withAppendedPath(
+                        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                        id.toString(),
+                    )
+
+                    photos.add(
+                        PhotoItem(
+                            id = id,
+                            uri = uri,
+                            displayName = displayName,
+                            dateAdded = dateAdded * 1000, // 秒からミリ秒に変換
+                            size = size,
+                            mimeType = mimeType,
+                        ),
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            Log.e("CameraViewModel", "写真の取得中にエラーが発生しました", e)
+        }
+
+        return photos
+    }
+
+    /**
+     * 写真の選択状態を切り替え
+     */
+    fun togglePhotoSelection(uri: Uri) {
+        val currentSelection = _selectedPhotos.value.toMutableSet()
+        if (currentSelection.contains(uri)) {
+            currentSelection.remove(uri)
+        } else {
+            currentSelection.add(uri)
+        }
+        _selectedPhotos.value = currentSelection
+
+        // 選択がなくなったら選択モードを終了
+        if (currentSelection.isEmpty()) {
+            _isSelectionMode.value = false
+        }
+    }
+
+    /**
+     * 選択モードを開始
+     */
+    fun startSelectionMode() {
+        _isSelectionMode.value = true
+        _selectedPhotos.value = emptySet()
+    }
+
+    /**
+     * 選択モードを終了
+     */
+    fun exitSelectionMode() {
+        _isSelectionMode.value = false
+        _selectedPhotos.value = emptySet()
+    }
+
+    /**
+     * 全選択/全選択解除
+     */
+    fun toggleSelectAll() {
+        if (_selectedPhotos.value.size == _allPhotos.value.size) {
+            // 全選択されている場合は全選択解除
+            _selectedPhotos.value = emptySet()
+        } else {
+            // そうでなければ全選択
+            _selectedPhotos.value = _allPhotos.value.map { it.uri }.toSet()
+        }
+    }
+
+    /**
+     * 選択をクリア
+     */
+    fun clearSelection() {
+        _selectedPhotos.value = emptySet()
+        _isSelectionMode.value = false
+    }
+
+    /**
+     * 選択された写真を削除
+     */
+    fun deleteSelectedPhotos(context: Context): Int {
+        val selectedUris = _selectedPhotos.value.toList()
+        return deleteMultiplePhotos(context, selectedUris)
+    }
+
+    /**
+     * 特定の写真を拡大表示用に設定
+     */
+    fun setCurrentViewingPhoto(photo: PhotoItem?) {
+        _currentViewingPhoto.value = photo
+    }
+
+    /**
+     * 次の写真に移動
+     */
+    fun goToNextPhoto() {
+        val currentPhoto = _currentViewingPhoto.value ?: return
+        val currentIndex = _allPhotos.value.indexOfFirst { it.id == currentPhoto.id }
+        if (currentIndex >= 0 && currentIndex < _allPhotos.value.size - 1) {
+            _currentViewingPhoto.value = _allPhotos.value[currentIndex + 1]
+        }
+    }
+
+    /**
+     * 前の写真に移動
+     */
+    fun goToPreviousPhoto() {
+        val currentPhoto = _currentViewingPhoto.value ?: return
+        val currentIndex = _allPhotos.value.indexOfFirst { it.id == currentPhoto.id }
+        if (currentIndex > 0) {
+            _currentViewingPhoto.value = _allPhotos.value[currentIndex - 1]
+        }
     }
 
     fun onCameraRebound() {

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -296,6 +296,7 @@ class CameraViewModel : ViewModel() {
                     getAllPhotosFromDevice(context)
                 }
                 _allPhotos.value = photos
+                _lastCapturedImageUri.value = photos.firstOrNull()?.uri
                 Log.d("CameraViewModel", "読み込んだ写真数: ${photos.size}")
             } catch (e: Exception) {
                 Log.e("CameraViewModel", "写真の読み込みに失敗しました", e)

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -51,7 +51,6 @@
     <string name="photo_deleted_successfully">写真を削除しました</string>
     <string name="photo_deletion_failed">写真の削除に失敗しました</string>
     <plurals name="photos_deleted_count">
-        <item quantity="one">%1$d 枚の写真を削除しました</item>
         <item quantity="other">%1$d 枚の写真を削除しました</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -47,5 +47,8 @@
     <string name="zoom_info">ズーム: %.1fx (%.1f-%.1fx)</string>
     <string name="photo_deleted_successfully">写真を削除しました</string>
     <string name="photo_deletion_failed">写真の削除に失敗しました</string>
-    <string name="photos_deleted_count">%1$d 枚の写真を削除しました</string>
+    <plurals name="photos_deleted_count">
+        <item quantity="one">%1$d 枚の写真を削除しました</item>
+        <item quantity="other">%1$d 枚の写真を削除しました</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -44,7 +44,7 @@
     <string name="delete_photo_title">写真を削除</string>
     <string name="delete_photo_message">この写真を削除しますか？この操作は元に戻せません。</string>
     <string name="cancel">キャンセル</string>
-    <string name="zoom_info">ズーム: %.1fx (%.1f-%.1fx)</string>
+    <string name="zoom_info">ズーム: %1$.1fx (%2$.1f-%3$.1fx)</string>
     <string name="photo_deleted_successfully">写真を削除しました</string>
     <string name="photo_deletion_failed">写真の削除に失敗しました</string>
     <plurals name="photos_deleted_count">

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -47,4 +47,5 @@
     <string name="zoom_info">ズーム: %.1fx (%.1f-%.1fx)</string>
     <string name="photo_deleted_successfully">写真を削除しました</string>
     <string name="photo_deletion_failed">写真の削除に失敗しました</string>
-</resources> 
+    <string name="photos_deleted_count">%1$d 枚の写真を削除しました</string>
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -42,8 +42,11 @@
     <string name="camera_preview_title">カメラプレビュー</string>
     <string name="camera_preview_description">実際のカメラ機能はここに表示されます</string>
     <string name="delete_photo_title">写真を削除</string>
+    <string name="delete_photo_confirmation">この写真を削除しますか？</string>
     <string name="delete_photo_message">この写真を削除しますか？この操作は元に戻せません。</string>
     <string name="cancel">キャンセル</string>
+    <string name="previous_photo">前の写真</string>
+    <string name="next_photo">次の写真</string>
     <string name="zoom_info">ズーム: %1$.1fx (%2$.1f-%3$.1fx)</string>
     <string name="photo_deleted_successfully">写真を削除しました</string>
     <string name="photo_deletion_failed">写真の削除に失敗しました</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,8 +42,11 @@
     <string name="camera_preview_title">Camera Preview</string>
     <string name="camera_preview_description">Actual camera functionality will be displayed here</string>
     <string name="delete_photo_title">Delete Photo</string>
+    <string name="delete_photo_confirmation">Are you sure you want to delete this photo?</string>
     <string name="delete_photo_message">Are you sure you want to delete this photo? This action cannot be undone.</string>
     <string name="cancel">Cancel</string>
+    <string name="previous_photo">Previous photo</string>
+    <string name="next_photo">Next photo</string>
     <string name="zoom_info">Zoom: %1$.1fx (%2$.1f-%3$.1fx)</string>
     <string name="photo_deleted_successfully">Photo deleted successfully</string>
     <string name="photo_deletion_failed">Failed to delete photo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,4 +47,5 @@
     <string name="zoom_info">Zoom: %.1fx (%.1f-%.1fx)</string>
     <string name="photo_deleted_successfully">Photo deleted successfully</string>
     <string name="photo_deletion_failed">Failed to delete photo</string>
+    <string name="photos_deleted_count">Deleted %1$d photos</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="delete_photo_title">Delete Photo</string>
     <string name="delete_photo_message">Are you sure you want to delete this photo? This action cannot be undone.</string>
     <string name="cancel">Cancel</string>
-    <string name="zoom_info">Zoom: %.1fx (%.1f-%.1fx)</string>
+    <string name="zoom_info">Zoom: %1$.1fx (%2$.1f-%3$.1fx)</string>
     <string name="photo_deleted_successfully">Photo deleted successfully</string>
     <string name="photo_deletion_failed">Failed to delete photo</string>
     <plurals name="photos_deleted_count">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,5 +47,8 @@
     <string name="zoom_info">Zoom: %.1fx (%.1f-%.1fx)</string>
     <string name="photo_deleted_successfully">Photo deleted successfully</string>
     <string name="photo_deletion_failed">Failed to delete photo</string>
-    <string name="photos_deleted_count">Deleted %1$d photos</string>
+    <plurals name="photos_deleted_count">
+        <item quantity="one">Deleted %1$d photo</item>
+        <item quantity="other">Deleted %1$d photos</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
## Summary
- extend `CameraViewModel` with gallery management
- load all photos from device media store
- support selecting and browsing photos
- add gallery UI with selection and deletion features

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0df51404c833088c0e03476dfda3f