### PR TITLE
docs: update readme for current setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -68,7 +68,7 @@ Jetpack Compose を用いた Android 向けカメラアプリ。CameraX によ�
 ## 🏗️ 技術スタック
 
 ### コア技術
-- **Language**: Kotlin 2.2.0
+- **Language**: Kotlin 1.9.25
 - **UI Framework**: Jetpack Compose 1.7.8
 - **Camera**: CameraX 1.4.2
 - **Architecture**: MVVM + StateFlow
@@ -77,12 +77,12 @@ Jetpack Compose を用いた Android 向けカメラアプリ。CameraX によ�
 - **Dependency Management**: Dependabot Automation
 
 ### 開発環境
-- **Android Studio**: Hedgehog以上推奨 (Kotlin 2.2.0対応)
-- **Gradle**: 8.5+ (Kotlin 2.2.0必須要件)
-- **Min SDK**: 24 (Android 7.0+)
-- **Target SDK**: 35 (Android 15)
-- **Compile SDK**: 35 (Android 15対応)
-- **JDK**: 11+ (Kotlin 2.2.0推奨)
+- **Android Studio**: Koala以上推奨 (Kotlin 1.9.25対応)
+- **Gradle**: 8.12+ (Android Gradle Plugin 8.12.1)
+- **Min SDK**: 25 (Android 7.1+)
+- **Target SDK**: 36 (Android 16)
+- **Compile SDK**: 36 (Android 16対応)
+- **JDK**: 11+ (Kotlin 1.9.25推奨)
 
 ## 🚀 使用方法
 
@@ -147,9 +147,9 @@ Jetpack Compose を用いた Android 向けカメラアプリ。CameraX によ�
 │   └── dependabot.yml                        # 依存関係自動更新設定
 │
 ├── 🔧 プロジェクト設定ファイル
-│   ├── build.gradle                           # プロジェクトレベルビルド設定 (Kotlin 2.2.0)
+│   ├── build.gradle                           # プロジェクトレベルビルド設定 (Kotlin 1.9.25)
 │   ├── settings.gradle                        # Gradle設定
-│   ├── gradle.properties                      # Gradleプロパティ (Kotlin 2.2.0最適化)
+│   ├── gradle.properties                      # Gradleプロパティ (Kotlin 1.9.25最適化)
 │   ├── local.properties                       # ローカル環境設定
 │   └── README.md                              # プロジェクト概要（このファイル）
 │
@@ -194,10 +194,10 @@ Jetpack Compose を用いた Android 向けカメラアプリ。CameraX によ�
 ## 🔧 セットアップ
 
 ### 前提条件
-- Android Studio Hedgehog以上 (Kotlin 2.2.0必須要件)
-- JDK 11以上 (Kotlin 2.2.0推奨)
-- Gradle 8.5以上 (Kotlin 2.2.0必須要件)
-- Android SDK 24以上
+- Android Studio Koala以上 (Kotlin 1.9.25必須要件)
+- JDK 11以上
+- Gradle 8.12以上
+- Android SDK 25以上
 
 ### インストール手順
 1. **リポジトリをクローン**
@@ -243,13 +243,14 @@ implementation "androidx.activity:activity-compose:1.10.1"
 
 // ViewModel & StateFlow (2.9.2)
 implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.9.2"
-implementation "androidx.core:core-ktx:1.16.0"
+implementation "androidx.core:core-ktx:1.17.0"
 
 // 画像処理 (2.7.0)
 implementation "io.coil-kt:coil-compose:2.7.0"
 
-// Kotlin 2.2.0 + Compose Compiler Plugin
-id 'org.jetbrains.kotlin.plugin.compose' version '2.2.0'
+// Kotlin 1.9.25 + Compose Compiler 1.5.15
+id 'org.jetbrains.kotlin.android' version '1.9.25'
+kotlinCompilerExtensionVersion = "1.5.15"
 ```
 
 ## 📈 パフォーマンス

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Jetpack Compose-based Android camera app providing real-time preview and photo c
 ## 🏗️ Tech Stack
 
 ### Core Technologies
-- **Language**: Kotlin 2.2.0
+- **Language**: Kotlin 1.9.25
 - **UI Framework**: Jetpack Compose 1.7.8
 - **Camera**: CameraX 1.4.2
 - **Architecture**: MVVM + StateFlow
@@ -77,12 +77,12 @@ Jetpack Compose-based Android camera app providing real-time preview and photo c
 - **Dependency Management**: Dependabot Automation
 
 ### Development Environment
-- **Android Studio**: Hedgehog or above (Kotlin 2.2.0 support required)
-- **Gradle**: 8.5+ (Kotlin 2.2.0 required)
-- **Min SDK**: 24 (Android 7.0+)
-- **Target SDK**: 35 (Android 15)
-- **Compile SDK**: 35 (Android 15 support)
-- **JDK**: 11+ (Kotlin 2.2.0 recommended)
+- **Android Studio**: Koala or above (Kotlin 1.9.25 support required)
+- **Gradle**: 8.12+ (Android Gradle Plugin 8.12.1)
+- **Min SDK**: 25 (Android 7.1+)
+- **Target SDK**: 36 (Android 16)
+- **Compile SDK**: 36 (Android 16 support)
+- **JDK**: 11+ (Kotlin 1.9.25 recommended)
 
 ## 🚀 How to Use
 
@@ -147,9 +147,9 @@ Jetpack Compose-based Android camera app providing real-time preview and photo c
 │   └── dependabot.yml                        # Automatic dependency update configuration
 │
 ├── 🔧 Project configuration files
-│   ├── build.gradle                           # Project-level build configuration (Kotlin 2.2.0)
+│   ├── build.gradle                           # Project-level build configuration (Kotlin 1.9.25)
 │   ├── settings.gradle                        # Gradle settings
-│   ├── gradle.properties                      # Gradle properties (Kotlin 2.2.0 optimization)
+│   ├── gradle.properties                      # Gradle properties (Kotlin 1.9.25 optimization)
 │   ├── local.properties                       # Local environment configuration
 │   └── README.md                              # Project overview (this file)
 │
@@ -194,10 +194,10 @@ Jetpack Compose-based Android camera app providing real-time preview and photo c
 ## 🔧 Setup
 
 ### Prerequisites
-- Android Studio Hedgehog or above (Kotlin 2.2.0 requirement)
-- JDK 11 or above (Kotlin 2.2.0 recommended)
-- Gradle 8.5 or above (Kotlin 2.2.0 requirement)
-- Android SDK 24 or above
+- Android Studio Koala or above (Kotlin 1.9.25 requirement)
+- JDK 11 or above
+- Gradle 8.12 or above
+- Android SDK 25 or above
 
 ### Installation Steps
 1. **Clone the repository**
@@ -243,13 +243,14 @@ implementation "androidx.activity:activity-compose:1.10.1"
 
 // ViewModel & StateFlow (2.9.2)
 implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.9.2"
-implementation "androidx.core:core-ktx:1.16.0"
+implementation "androidx.core:core-ktx:1.17.0"
 
 // Image Processing (2.7.0)
 implementation "io.coil-kt:coil-compose:2.7.0"
 
-// Kotlin 2.2.0 + Compose Compiler Plugin
-id 'org.jetbrains.kotlin.plugin.compose' version '2.2.0'
+// Kotlin 1.9.25 + Compose Compiler 1.5.15
+id 'org.jetbrains.kotlin.android' version '1.9.25'
+kotlinCompilerExtensionVersion = "1.5.15"
 ```
 
 ## 📈 Performance


### PR DESCRIPTION
## Summary
- refresh README details in English and Japanese for current dependencies
- note Kotlin 1.9.25, Android Studio Koala, Gradle 8.12+, and SDK 36

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b940635500833081160c873630e4a4