### PR TITLE
Grant permissions for UI tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,6 +139,7 @@ dependencies {
     kaptTest 'com.google.dagger:hilt-android-compiler:2.52'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/app/src/androidTest/java/com/example/vtubercamera/ui/screens/CameraScreenIconTest.kt
+++ b/app/src/androidTest/java/com/example/vtubercamera/ui/screens/CameraScreenIconTest.kt
@@ -1,10 +1,13 @@
 package com.example.vtubercamera.ui.screens
 
+import android.Manifest
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.assertIsDisplayed
+import androidx.test.rule.GrantPermissionRule
 import com.example.vtubercamera.R
+import com.example.vtubercamera.utils.PermissionUtils
 import org.junit.Rule
 import org.junit.Test
 
@@ -12,6 +15,13 @@ class CameraScreenIconTest {
 
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    // Automatically grant camera and gallery permissions before each test
+    @get:Rule
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.CAMERA,
+        *PermissionUtils.getRequiredMediaPermissions()
+    )
 
     @Test
     fun switchCameraIcon_isDisplayed() {


### PR DESCRIPTION
## Summary
- grant camera and media permissions automatically in UI tests
- include AndroidX test rules dependency

## Testing
- `./gradlew test assembleDebugAndroidTest` *(fails: build-tools and platform packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c21c6634b4833080803353a88eabd7