### PR TITLE
Add avatar selection navigation flow

### DIFF
--- a/app/src/main/java/com/example/vtubercamera/MainActivity.kt
+++ b/app/src/main/java/com/example/vtubercamera/MainActivity.kt
@@ -6,17 +6,25 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.example.vtubercamera.ui.screens.ARCameraScreen
+import com.example.vtubercamera.ui.screens.AvatarLibraryScreen
 import com.example.vtubercamera.ui.screens.CameraScreen
 import com.example.vtubercamera.ui.theme.VTuberCameraTheme
 import com.example.vtubercamera.utils.initializeAndroid15
 import dagger.hilt.android.AndroidEntryPoint
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.vtubercamera.ui.viewmodels.CameraViewModel
+
+private enum class MainScreen {
+    CAMERA,
+    AR,
+    AVATAR_LIBRARY
+}
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -30,16 +38,34 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    var isARScreenVisible by rememberSaveable { mutableStateOf(false) }
+                    val cameraViewModel: CameraViewModel = hiltViewModel()
+                    var currentScreen by rememberSaveable { mutableStateOf(MainScreen.CAMERA) }
 
-                    if (isARScreenVisible) {
-                        ARCameraScreen(
-                            onNavigateBack = { isARScreenVisible = false }
-                        )
-                    } else {
-                        CameraScreen(
-                            onNavigateToAR = { isARScreenVisible = true }
-                        )
+                    when (currentScreen) {
+                        MainScreen.CAMERA -> {
+                            CameraScreen(
+                                onNavigateToAR = { currentScreen = MainScreen.AR },
+                                viewModel = cameraViewModel
+                            )
+                        }
+
+                        MainScreen.AR -> {
+                            ARCameraScreen(
+                                onNavigateBack = { currentScreen = MainScreen.CAMERA },
+                                onNavigateToAvatarLibrary = { currentScreen = MainScreen.AVATAR_LIBRARY },
+                                viewModel = cameraViewModel
+                            )
+                        }
+
+                        MainScreen.AVATAR_LIBRARY -> {
+                            AvatarLibraryScreen(
+                                onNavigateBack = { currentScreen = MainScreen.AR },
+                                onAvatarSelected = { avatar ->
+                                    cameraViewModel.selectAvatarFromLibrary(avatar.id)
+                                    currentScreen = MainScreen.AR
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/AvatarLibraryScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/AvatarLibraryScreen.kt
@@ -62,6 +62,7 @@ import com.example.vtubercamera.ui.viewmodels.AvatarLibraryViewModel
 @Composable
 fun AvatarLibraryScreen(
     onNavigateBack: () -> Unit,
+    onAvatarSelected: (AvatarInfo) -> Unit = {},
     viewModel: AvatarLibraryViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -162,7 +163,10 @@ fun AvatarLibraryScreen(
                         avatars = uiState.avatars,
                         selectedAvatarId = uiState.selectedAvatarId,
                         mode = AvatarListMode.LIST,
-                        onAvatarClick = { viewModel.selectAvatar(it.id) },
+                        onAvatarClick = {
+                            viewModel.selectAvatar(it.id)
+                            onAvatarSelected(it)
+                        },
                         onFavoriteClick = { viewModel.toggleFavorite(it.id) },
                         onRenameClick = { viewModel.showRenameDialog(it.id) },
                         onDeleteClick = { pendingDeleteId = it.id },


### PR DESCRIPTION
## Summary
- add a simple screen state machine in MainActivity to navigate between camera, AR camera, and avatar library
- wire avatar library selections to load the chosen avatar into the shared CameraViewModel
- allow returning to AR view automatically after picking an avatar

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b31aabee08330b1413c475a59b715)