### PR TITLE
Decouple AR feature session initialization

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,9 +72,9 @@ android {
         freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
     }
     buildFeatures {
-        viewBinding true
-        compose true
-        buildConfig true
+        viewBinding = true
+        compose = true
+        buildConfig = true
     }
     
     composeOptions {

--- a/app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt
+++ b/app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt
@@ -16,6 +16,10 @@ import javax.inject.Inject
 class ARFeature @Inject constructor(
     private val arRepository: ARRepository,
 ) {
+    
+    companion object{
+        private const val TAG = "ARFeature"
+    }
 
     fun enableARMode(
         scope: CoroutineScope,
@@ -27,13 +31,13 @@ class ARFeature @Inject constructor(
         ) -> Unit,
     ) {
         if (uiStateProvider().isARMode) {
-            Log.d("CameraViewModel", "AR mode already enabled")
+            Log.d(TAG, "AR mode already enabled")
             return
         }
 
         scope.launch {
             try {
-                Log.d("CameraViewModel", "Enabling AR mode...")
+                Log.d(TAG, "Enabling AR mode...")
                 updateUiState {
                     copy(
                         ar = ar.copy(
@@ -47,7 +51,7 @@ class ARFeature @Inject constructor(
 
                 startSession(
                     {
-                        Log.d("CameraViewModel", "AR session ready")
+                        Log.d(TAG, "AR session ready")
                         observeARStates(
                             scope = scope,
                             updateUiState = updateUiState,
@@ -55,7 +59,7 @@ class ARFeature @Inject constructor(
                         )
                     },
                     { error ->
-                        Log.e("CameraViewModel", "AR session initialization failed: $error")
+                        Log.e(TAG, "AR session initialization failed: $error")
                         updateUiState { copy(ar = ar.copy(arError = error)) }
                         disableARMode(
                             scope = scope,
@@ -65,7 +69,7 @@ class ARFeature @Inject constructor(
                     }
                 )
             } catch (e: Exception) {
-                Log.e("CameraViewModel", "Failed to enable AR mode", e)
+                Log.e(TAG, "Failed to enable AR mode", e)
                 updateUiState {
                     copy(ar = ar.copy(arError = ARError.SessionError("Failed to enable AR mode: ${e.message}")))
                 }
@@ -84,13 +88,13 @@ class ARFeature @Inject constructor(
         uiStateProvider: UiStateProvider,
     ) {
         if (!uiStateProvider().isARMode) {
-            Log.d("CameraViewModel", "AR mode already disabled")
+            Log.d(TAG, "AR mode already disabled")
             return
         }
 
         scope.launch {
             try {
-                Log.d("CameraViewModel", "Disabling AR mode...")
+                Log.d(TAG, "Disabling AR mode...")
 
                 arRepository.destroySession()
 
@@ -116,9 +120,9 @@ class ARFeature @Inject constructor(
                     )
                 }
 
-                Log.d("CameraViewModel", "AR mode disabled")
+                Log.d(TAG, "AR mode disabled")
             } catch (e: Exception) {
-                Log.e("CameraViewModel", "Error disabling AR mode", e)
+                Log.e(TAG, "Error disabling AR mode", e)
             }
         }
     }
@@ -167,7 +171,7 @@ class ARFeature @Inject constructor(
 
         scope.launch {
             arRepository.trackingState.collect { trackingState ->
-                Log.d("CameraViewModel", "AR tracking state changed: $trackingState")
+                Log.d(TAG, "AR tracking state changed: $trackingState")
                 val currentState = uiStateProvider()
                 if (currentState.avatarState.model != null) {
                     val shouldShow = trackingState == TrackingState.TRACKING

--- a/app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt
+++ b/app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt
@@ -1,8 +1,6 @@
 package com.example.vtubercamera.domain.ar
 
-import android.content.Context
 import android.util.Log
-import androidx.lifecycle.LifecycleOwner
 import com.example.vtubercamera.data.ARRepository
 import com.example.vtubercamera.data.vrm.ARCameraState
 import com.example.vtubercamera.data.vrm.ARError
@@ -20,11 +18,13 @@ class ARFeature @Inject constructor(
 ) {
 
     fun enableARMode(
-        context: Context,
-        lifecycleOwner: LifecycleOwner,
         scope: CoroutineScope,
         updateUiState: UiStateUpdater,
         uiStateProvider: UiStateProvider,
+        startSession: suspend (
+            onSessionReady: () -> Unit,
+            onError: (ARError) -> Unit,
+        ) -> Unit,
     ) {
         if (uiStateProvider().isARMode) {
             Log.d("CameraViewModel", "AR mode already enabled")
@@ -45,9 +45,7 @@ class ARFeature @Inject constructor(
                     )
                 }
 
-                arRepository.initializeSession(
-                    context = context,
-                    lifecycleOwner = lifecycleOwner,
+                startSession(
                     onSessionReady = {
                         Log.d("CameraViewModel", "AR session ready")
                         observeARStates(
@@ -126,11 +124,13 @@ class ARFeature @Inject constructor(
     }
 
     fun toggleARMode(
-        context: Context,
-        lifecycleOwner: LifecycleOwner,
         scope: CoroutineScope,
         updateUiState: UiStateUpdater,
         uiStateProvider: UiStateProvider,
+        startSession: suspend (
+            onSessionReady: () -> Unit,
+            onError: (ARError) -> Unit,
+        ) -> Unit,
     ) {
         if (uiStateProvider().isARMode) {
             disableARMode(
@@ -140,11 +140,10 @@ class ARFeature @Inject constructor(
             )
         } else {
             enableARMode(
-                context = context,
-                lifecycleOwner = lifecycleOwner,
                 scope = scope,
                 updateUiState = updateUiState,
                 uiStateProvider = uiStateProvider,
+                startSession = startSession,
             )
         }
     }

--- a/app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt
+++ b/app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt
@@ -46,7 +46,7 @@ class ARFeature @Inject constructor(
                 }
 
                 startSession(
-                    onSessionReady = {
+                    {
                         Log.d("CameraViewModel", "AR session ready")
                         observeARStates(
                             scope = scope,
@@ -54,7 +54,7 @@ class ARFeature @Inject constructor(
                             uiStateProvider = uiStateProvider,
                         )
                     },
-                    onError = { error ->
+                    { error ->
                         Log.e("CameraViewModel", "AR session initialization failed: $error")
                         updateUiState { copy(ar = ar.copy(arError = error)) }
                         disableARMode(

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/ARSessionStarter.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/ARSessionStarter.kt
@@ -1,0 +1,25 @@
+package com.example.vtubercamera.ui.viewmodels
+
+import android.content.Context
+import androidx.lifecycle.LifecycleOwner
+import com.example.vtubercamera.data.ARRepository
+import com.example.vtubercamera.data.vrm.ARError
+import javax.inject.Inject
+
+class ARSessionStarter @Inject constructor(
+    private val arRepository: ARRepository,
+) {
+    suspend fun start(
+        context: Context,
+        lifecycleOwner: LifecycleOwner,
+        onSessionReady: () -> Unit,
+        onError: (ARError) -> Unit,
+    ) {
+        arRepository.initializeSession(
+            context = context,
+            lifecycleOwner = lifecycleOwner,
+            onSessionReady = onSessionReady,
+            onError = onError,
+        )
+    }
+}

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -692,11 +692,17 @@ class CameraViewModel @Inject constructor(
         lifecycleOwner: androidx.lifecycle.LifecycleOwner
     ) {
         arFeature.enableARMode(
-            context = context,
-            lifecycleOwner = lifecycleOwner,
             scope = viewModelScope,
             updateUiState = this::updateUiState,
             uiStateProvider = { _uiState.value },
+            startSession = { onSessionReady, onError ->
+                arRepository.initializeSession(
+                    context = context,
+                    lifecycleOwner = lifecycleOwner,
+                    onSessionReady = onSessionReady,
+                    onError = onError,
+                )
+            },
         )
     }
 
@@ -719,11 +725,17 @@ class CameraViewModel @Inject constructor(
         lifecycleOwner: androidx.lifecycle.LifecycleOwner
     ) {
         arFeature.toggleARMode(
-            context = context,
-            lifecycleOwner = lifecycleOwner,
             scope = viewModelScope,
             updateUiState = this::updateUiState,
             uiStateProvider = { _uiState.value },
+            startSession = { onSessionReady, onError ->
+                arRepository.initializeSession(
+                    context = context,
+                    lifecycleOwner = lifecycleOwner,
+                    onSessionReady = onSessionReady,
+                    onError = onError,
+                )
+            },
         )
     }
 

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -32,11 +32,9 @@ import com.example.vtubercamera.domain.camera.LensSwitchFeature
 import com.example.vtubercamera.domain.lighting.LightingFeature
 import com.example.vtubercamera.utils.CameraCapabilityManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.SharingStarted
@@ -57,6 +55,8 @@ class CameraViewModel @Inject constructor(
     private val arFeature: ARFeature,
     private val avatarFeature: AvatarFeature,
     private val lightingFeature: LightingFeature,
+    private val bootstrapper: CameraViewModelBootstrapper,
+    private val arSessionStarter: ARSessionStarter,
 ) : ViewModel() {
 
     // UI状態の管理
@@ -320,64 +320,10 @@ class CameraViewModel @Inject constructor(
     }
 
     init {
-        viewModelScope.launch {
-            mediaRepository.getAllPhotos().collect { photos ->
-                updateUiState { copy(gallery = gallery.copy(allPhotos = photos)) }
-            }
-        }
-
-        viewModelScope.launch {
-            mediaRepository.getARPhotos().collect { photos ->
-                updateUiState { copy(gallery = gallery.copy(arPhotos = photos)) }
-            }
-        }
-
-        viewModelScope.launch {
-            mediaRepository.getNormalPhotos().collect { photos ->
-                updateUiState { copy(gallery = gallery.copy(normalPhotos = photos)) }
-            }
-        }
-
-        viewModelScope.launch {
-            mediaRepository.getLatestPhotoUri().collect { latestUri ->
-                updateUiState { copy(camera = camera.copy(latestLibraryPhotoUri = latestUri)) }
-            }
-        }
-
-        // Initialize camera capabilities
-        lensSwitchFeature.initializeCameraCapabilities(
+        bootstrapper.start(
             scope = viewModelScope,
             updateUiState = this::updateUiState,
-            uiStateProvider = { _uiState.value }
-        )
-
-        // Initialize AR state observation
-        initializeARStateObservation()
-
-        // Initialize avatar library (deferred to avoid initialization race conditions)
-        viewModelScope.launch {
-            try {
-                avatarFeature.initializeAvatarLibrary(
-                    scope = viewModelScope,
-                    updateUiState = this@CameraViewModel::updateUiState,
-                    uiStateProvider = { _uiState.value },
-                )
-            } catch (e: Exception) {
-                Log.e("CameraViewModel", "Failed to initialize avatar library", e)
-                updateUiState {
-                    copy(
-                        avatarLibraryState = avatarLibraryState.copy(
-                            avatarLibraryError = "Failed to initialize avatar library: ${e.message}"
-                        )
-                    )
-                }
-            }
-        }
-
-        // Initialize avatar control observers
-        avatarFeature.startAvatarControlObservers(
-            scope = viewModelScope,
-            updateUiState = this::updateUiState,
+            uiStateProvider = { _uiState.value },
         )
     }
 
@@ -674,14 +620,6 @@ class CameraViewModel @Inject constructor(
         }
     }
 
-    /**
-     * Initialize AR state observation
-     */
-    private fun initializeARStateObservation() {
-        // This will be called when AR mode is enabled
-        // The actual observation starts in observeARStates()
-    }
-
     // ========== AR Mode Functions ==========
 
     /**
@@ -696,7 +634,7 @@ class CameraViewModel @Inject constructor(
             updateUiState = this::updateUiState,
             uiStateProvider = { _uiState.value },
             startSession = { onSessionReady, onError ->
-                arRepository.initializeSession(
+                arSessionStarter.start(
                     context = context,
                     lifecycleOwner = lifecycleOwner,
                     onSessionReady = onSessionReady,
@@ -729,7 +667,7 @@ class CameraViewModel @Inject constructor(
             updateUiState = this::updateUiState,
             uiStateProvider = { _uiState.value },
             startSession = { onSessionReady, onError ->
-                arRepository.initializeSession(
+                arSessionStarter.start(
                     context = context,
                     lifecycleOwner = lifecycleOwner,
                     onSessionReady = onSessionReady,

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelBootstrapper.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelBootstrapper.kt
@@ -1,0 +1,78 @@
+package com.example.vtubercamera.ui.viewmodels
+
+import android.util.Log
+import com.example.vtubercamera.data.MediaRepository
+import com.example.vtubercamera.domain.avatar.AvatarFeature
+import com.example.vtubercamera.domain.camera.LensSwitchFeature
+import com.example.vtubercamera.domain.camera.UiStateProvider
+import com.example.vtubercamera.domain.camera.UiStateUpdater
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class CameraViewModelBootstrapper @Inject constructor(
+    private val mediaRepository: MediaRepository,
+    private val lensSwitchFeature: LensSwitchFeature,
+    private val avatarFeature: AvatarFeature,
+) {
+
+    fun start(
+        scope: CoroutineScope,
+        updateUiState: UiStateUpdater,
+        uiStateProvider: UiStateProvider,
+    ) {
+        scope.launch {
+            mediaRepository.getAllPhotos().collect { photos ->
+                updateUiState { copy(gallery = gallery.copy(allPhotos = photos)) }
+            }
+        }
+
+        scope.launch {
+            mediaRepository.getARPhotos().collect { photos ->
+                updateUiState { copy(gallery = gallery.copy(arPhotos = photos)) }
+            }
+        }
+
+        scope.launch {
+            mediaRepository.getNormalPhotos().collect { photos ->
+                updateUiState { copy(gallery = gallery.copy(normalPhotos = photos)) }
+            }
+        }
+
+        scope.launch {
+            mediaRepository.getLatestPhotoUri().collect { latestUri ->
+                updateUiState { copy(camera = camera.copy(latestLibraryPhotoUri = latestUri)) }
+            }
+        }
+
+        lensSwitchFeature.initializeCameraCapabilities(
+            scope = scope,
+            updateUiState = updateUiState,
+            uiStateProvider = uiStateProvider,
+        )
+
+        scope.launch {
+            try {
+                avatarFeature.initializeAvatarLibrary(
+                    scope = scope,
+                    updateUiState = updateUiState,
+                    uiStateProvider = uiStateProvider,
+                )
+            } catch (e: Exception) {
+                Log.e("CameraViewModel", "Failed to initialize avatar library", e)
+                updateUiState {
+                    copy(
+                        avatarLibraryState = avatarLibraryState.copy(
+                            avatarLibraryError = "Failed to initialize avatar library: ${e.message}"
+                        )
+                    )
+                }
+            }
+        }
+
+        avatarFeature.startAvatarControlObservers(
+            scope = scope,
+            updateUiState = updateUiState,
+        )
+    }
+}

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelBootstrapper.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelBootstrapper.kt
@@ -15,6 +15,10 @@ class CameraViewModelBootstrapper @Inject constructor(
     private val lensSwitchFeature: LensSwitchFeature,
     private val avatarFeature: AvatarFeature,
 ) {
+    companion object{
+       private const val TAG = "CameraViewModelBootstrapper"
+    }
+
 
     fun start(
         scope: CoroutineScope,
@@ -59,7 +63,7 @@ class CameraViewModelBootstrapper @Inject constructor(
                     uiStateProvider = uiStateProvider,
                 )
             } catch (e: Exception) {
-                Log.e("CameraViewModel", "Failed to initialize avatar library", e)
+                Log.e(TAG, "Failed to initialize avatar library", e)
                 updateUiState {
                     copy(
                         avatarLibraryState = avatarLibraryState.copy(

--- a/app/src/test/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelTest.kt
+++ b/app/src/test/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelTest.kt
@@ -146,6 +146,13 @@ class CameraViewModelTest {
         )
         val lightingFeature = LightingFeature(lightingSystem = mockLightingSystem)
 
+        val bootstrapper = CameraViewModelBootstrapper(
+            mediaRepository = mockMediaRepository,
+            lensSwitchFeature = lensSwitchFeature,
+            avatarFeature = avatarFeature,
+        )
+        val arSessionStarter = ARSessionStarter(arRepository = mockARRepository)
+
         viewModel = CameraViewModel(
             cameraRepository = mockCameraRepository,
             mediaRepository = mockMediaRepository,
@@ -155,6 +162,8 @@ class CameraViewModelTest {
             arFeature = arFeature,
             avatarFeature = avatarFeature,
             lightingFeature = lightingFeature,
+            bootstrapper = bootstrapper,
+            arSessionStarter = arSessionStarter,
         )
 
         // Run ViewModel init coroutines

--- a/docs/AntiPatternReview.md
+++ b/docs/AntiPatternReview.md
@@ -3,13 +3,23 @@
 This document summarizes anti-patterns identified in the current codebase with respect to common Android architecture guidance (e.g., avoiding fat ViewModels, keeping domain logic platform-agnostic).
 
 ## Fat ViewModel responsibilities
-- `CameraViewModel` orchestrates camera controls, gallery management, AR mode toggling, avatar loading/cleanup, and lighting state within a single class. The ViewModel subscribes directly to multiple repository flows, initializes capabilities, and delegates numerous feature operations (photo capture/deletion, AR enable/disable, avatar management, etc.) from one place, resulting in a class exceeding 1,000 lines of mixed responsibilities.
-  - Initialization pulls photo streams, tracks latest media, sets up camera capabilities, and bootstraps avatar/AR observers in the constructor scope.【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L322-L328】
-  - The same class handles gallery mutations such as deleting single/multiple photos and clearing captured images, alongside AR lifecycle and avatar controls.【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L448-L520】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L685-L760】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L1009-L1080】
-  - Concentrating disparate concerns here risks the "fat ViewModel" anti-pattern noted in the design guidance.
+- `CameraViewModel` is still a large class (>1,000 lines) and remains the central coordinator for camera UI, gallery UI, AR toggling, avatar controls, and lighting-related UI state. While several responsibilities have been extracted into “Feature” classes, the ViewModel still wires many inputs/outputs together and maintains a large UI state surface.
+  - **Improved (but not eliminated):** repository subscriptions / bootstrapping were extracted into `CameraViewModelBootstrapper`.
+    - Photo streams (`MediaRepository.getAllPhotos()` / `getARPhotos()` / `getNormalPhotos()` / `getLatestPhotoUri()`) are collected in `CameraViewModelBootstrapper`, not directly inside the ViewModel.
+    - Lens capability initialization and avatar library bootstrap/observers are also started from `CameraViewModelBootstrapper`.
+    - References: [app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt](../app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt), [app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelBootstrapper.kt](../app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelBootstrapper.kt)
+  - **Still “fat” due to UI surface area:** the ViewModel exposes many derived `StateFlow`s “for backward compatibility” on top of a single `CameraUiState`, which materially contributes to file size and mixed concerns.
+  - **Direct repository calls remain:** some operations are still implemented directly in the ViewModel (e.g., normal photo capture via `CameraRepository.capturePhoto`, camera switching callback wiring, and AR photo capture/compositing logic), which keeps camera/media concerns anchored in the ViewModel.
+  - Net: responsibility extraction is underway, but `CameraViewModel` is still at risk of becoming an “all-purpose coordinator” due to API surface and cross-feature wiring.
 
 ## Context-dependent domain logic (addressed)
-- `ARFeature` no longer requires `Context` or `LifecycleOwner`; session start is injected as a callback, keeping domain logic platform-agnostic while preserving repository-driven AR observations.【F:app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt†L1-L188】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L625-L678】
+- `ARFeature` no longer requires `Context` or `LifecycleOwner`. Instead, session start is injected as a callback (`startSession`), keeping the feature logic decoupled from Android component lifecycles.
+  - The platform-bound session initialization is encapsulated in `ARSessionStarter`, which delegates to `ARRepository.initializeSession(context, lifecycleOwner, ...)`.
+  - References: [app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt](../app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt), [app/src/main/java/com/example/vtubercamera/ui/viewmodels/ARSessionStarter.kt](../app/src/main/java/com/example/vtubercamera/ui/viewmodels/ARSessionStarter.kt)
 
 ## Repository scope creep (potential)
-- Because `ARFeature` invokes session initialization and error handling directly through `ARRepository` while also updating UI-related flags, the boundary between data acquisition and UI state orchestration is blurred. Further separating platform/session management from domain orchestration would reduce the risk of the repository or feature layer becoming an all-purpose coordinator.
+- `ARRepository` remains strongly platform-oriented (it requires `Context`/`LifecycleOwner` and owns session lifecycle methods like `initializeSession()` / `pauseSession()` / `resumeSession()` / `destroySession()`), which is expected for an ARCore-backed implementation.
+- However, the boundary between “domain feature” and “UI orchestration” is still somewhat blurred:
+  - `ARFeature` updates UI-related state (e.g., toggling avatar visibility based on tracking state) and triggers session teardown (`destroySession()`), so it functions as both a coordinator and a state-to-UI mapper.
+  - If the architecture continues to grow, consider further splitting responsibilities so that the AR layer provides state/events, and the UI layer decides how to project that into UI state (e.g., avatar visibility/transform resets).
+  - Reference: [app/src/main/java/com/example/vtubercamera/data/ARRepository.kt](../app/src/main/java/com/example/vtubercamera/data/ARRepository.kt)

--- a/docs/AntiPatternReview.md
+++ b/docs/AntiPatternReview.md
@@ -9,7 +9,7 @@ This document summarizes anti-patterns identified in the current codebase with r
   - Concentrating disparate concerns here risks the "fat ViewModel" anti-pattern noted in the design guidance.
 
 ## Context-dependent domain logic (addressed)
-- `ARFeature` no longer requires `Context` or `LifecycleOwner`; session start is injected as a callback, keeping domain logic platform-agnostic while preserving repository-driven AR observations.【F:app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt†L1-L142】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L683-L723】
+- `ARFeature` no longer requires `Context` or `LifecycleOwner`; session start is injected as a callback, keeping domain logic platform-agnostic while preserving repository-driven AR observations.【F:app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt†L1-L188】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L625-L678】
 
 ## Repository scope creep (potential)
 - Because `ARFeature` invokes session initialization and error handling directly through `ARRepository` while also updating UI-related flags, the boundary between data acquisition and UI state orchestration is blurred. Further separating platform/session management from domain orchestration would reduce the risk of the repository or feature layer becoming an all-purpose coordinator.

--- a/docs/AntiPatternReview.md
+++ b/docs/AntiPatternReview.md
@@ -4,7 +4,7 @@ This document summarizes anti-patterns identified in the current codebase with r
 
 ## Fat ViewModel responsibilities
 - `CameraViewModel` orchestrates camera controls, gallery management, AR mode toggling, avatar loading/cleanup, and lighting state within a single class. The ViewModel subscribes directly to multiple repository flows, initializes capabilities, and delegates numerous feature operations (photo capture/deletion, AR enable/disable, avatar management, etc.) from one place, resulting in a class exceeding 1,000 lines of mixed responsibilities.
-  - Initialization pulls photo streams, tracks latest media, sets up camera capabilities, and bootstraps avatar/AR observers in the constructor scope.【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L322-L382】
+  - Initialization pulls photo streams, tracks latest media, sets up camera capabilities, and bootstraps avatar/AR observers in the constructor scope.【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L322-L328】
   - The same class handles gallery mutations such as deleting single/multiple photos and clearing captured images, alongside AR lifecycle and avatar controls.【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L448-L520】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L685-L760】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L1009-L1080】
   - Concentrating disparate concerns here risks the "fat ViewModel" anti-pattern noted in the design guidance.
 

--- a/docs/AntiPatternReview.md
+++ b/docs/AntiPatternReview.md
@@ -1,0 +1,15 @@
+# Anti-Pattern Review
+
+This document summarizes anti-patterns identified in the current codebase with respect to common Android architecture guidance (e.g., avoiding fat ViewModels, keeping domain logic platform-agnostic).
+
+## Fat ViewModel responsibilities
+- `CameraViewModel` orchestrates camera controls, gallery management, AR mode toggling, avatar loading/cleanup, and lighting state within a single class. The ViewModel subscribes directly to multiple repository flows, initializes capabilities, and delegates numerous feature operations (photo capture/deletion, AR enable/disable, avatar management, etc.) from one place, resulting in a class exceeding 1,000 lines of mixed responsibilities.
+  - Initialization pulls photo streams, tracks latest media, sets up camera capabilities, and bootstraps avatar/AR observers in the constructor scope.【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L322-L382】
+  - The same class handles gallery mutations such as deleting single/multiple photos and clearing captured images, alongside AR lifecycle and avatar controls.【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L448-L520】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L685-L760】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L1009-L1080】
+  - Concentrating disparate concerns here risks the "fat ViewModel" anti-pattern noted in the design guidance.
+
+## Context-dependent domain logic (addressed)
+- `ARFeature` no longer requires `Context` or `LifecycleOwner`; session start is injected as a callback, keeping domain logic platform-agnostic while preserving repository-driven AR observations.【F:app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt†L1-L142】【F:app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt†L683-L723】
+
+## Repository scope creep (potential)
+- Because `ARFeature` invokes session initialization and error handling directly through `ARRepository` while also updating UI-related flags, the boundary between data acquisition and UI state orchestration is blurred. Further separating platform/session management from domain orchestration would reduce the risk of the repository or feature layer becoming an all-purpose coordinator.


### PR DESCRIPTION
## Summary
- remove Android Context and LifecycleOwner dependencies from the ARFeature by using an injected session initializer callback
- update CameraViewModel to provide the AR session initialization callback and keep domain logic platform-agnostic
- refresh anti-pattern documentation to note the context dependency resolution

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bdc5e698c8330908603f100fc4fbc)