### PR TITLE
Add Copilot guidance, SKILL docs, and android unit test runner script

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,68 @@
+# Repository overview (for GitHub Copilot)
+
+## What this repo is
+- Product: VTuber Camera（Android）
+- Purpose: Jetpack ComposeベースのVTuber/コンテンツクリエイター向けカメラアプリ。リアルタイムプレビューと写真撮影を提供。
+- Primary modules: app
+- Tech stack: Kotlin, Gradle, Jetpack Compose, Hilt, Coroutines/StateFlow, CameraX, Material 3, Coil
+
+## How to navigate
+- Entry points
+  - App: `:app` (`app/src/main/java/com/example/vtubercamera/MainActivity.kt`, `VtuberCameraApp.kt`)
+  - Domain: `app/src/main/java/com/example/vtubercamera/ui/viewmodels` (状態管理とユースケース相当)
+  - Data: `app/src/main/java/com/example/vtubercamera/data` (Repository/データモデル)
+  - UI: `app/src/main/java/com/example/vtubercamera/ui` (Compose screens/components/theme)
+- Architecture rules
+  - UI -> Domain -> Data の依存方向を守る
+  - Android framework 依存は UI 層に寄せる
+  - Side effects は境界（Repository等）に閉じ込める
+
+## Coding conventions
+- Kotlin style: 既存のコードスタイルに合わせる（Compose/MVVM）。
+- Naming:
+  - Composable: `PascalCase`
+  - ViewModel: `*ViewModel`
+  - Repository: `XxxRepository` / `XxxRepositoryImpl`
+- Nullability: 原則 non-null、例外は理由コメント必須
+- Threading: suspend/Coroutine を基本、dispatcher は注入可能に
+
+## Build & test (local)
+### Quick start
+- Build:
+  - `./gradlew assembleDebug`
+- Unit tests (JVM):
+  - `./gradlew testDebugUnitTest`
+- Lint/static analysis:
+  - `./gradlew lintDebug`
+
+### CI expectations
+- PR では少なくとも以下が通ること:
+  - unit tests
+  - lint
+
+## How to make changes safely
+- Prefer small diffs; keep behavior changes isolated
+- When changing production logic:
+  - add/update unit tests first (or in same PR)
+  - explain risk & rollback notes in PR description
+- Avoid:
+  - “とりあえず通すため”のテスト弱体化
+  - 依存方向の逆転（UIがDataに直依存など）
+
+## Common gotchas (project-specific)
+- Flavors/buildTypes:
+  - Available: debug/release
+- Versioning:
+  - minSdk: 25
+  - targetSdk: 36
+  - compileSdk: 36
+- Feature flags / BuildConfig:
+  - 現状は特別な機構なし
+
+## What I want Copilot to do
+- When asked to implement code:
+  - follow existing architecture & module boundaries
+  - include tests for non-trivial logic
+  - show exact Gradle commands to validate
+- When unsure:
+  - search existing patterns in the repo before inventing new abstractions

--- a/.github/skills/SKILL.md
+++ b/.github/skills/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: android-camera
+description: Guidance for implementing and reviewing Android camera features in VTuber Camera.
+---
+
+# Skill Instructions
+
+## Focus Areas
+- Kotlin + Jetpack Compose UI patterns for camera flows
+- CameraX integration (preview, capture, lens switching, zoom, flash)
+- Hilt DI, repository pattern, and StateFlow-driven MVVM
+- Android permissions, storage (MediaStore), and lifecycle handling
+
+## Code Expectations
+- Prefer Kotlin idioms (sealed classes, data classes, coroutines/Flow)
+- Use Compose best practices (state hoisting, remember, derivedStateOf)
+- Keep camera-related logic in `data/` repositories and expose ViewModel state
+- Add new UI in `ui/components` or `ui/screens` with string resources
+- Keep performance in mind (avoid heavy work on main thread)
+
+## Testing & Quality
+- Favor unit tests for ViewModels and repositories when feasible
+- Follow existing Gradle tasks and VSCode task definitions for tests
+- Update documentation in `docs/` when adding developer workflows

--- a/.github/skills/android-unit-testing/SKILL.md
+++ b/.github/skills/android-unit-testing/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: android-unit-testing
+description: Run Android JVM unit tests via Gradle, collect reports, and fix failures. Use when asked to run/repair unit tests or CI test failures.
+---
+
+# Scope
+- JVM unit tests (Gradle `test*UnitTest`) first.
+- Instrumented tests are out of scope unless explicitly requested.
+
+# Preconditions
+- Use the repo's Gradle Wrapper (`./gradlew`).
+- Prefer deterministic commands; avoid “try random flags”.
+
+# Step-by-step
+## 1) Discover test tasks
+1. List modules and test tasks:
+   - `./gradlew tasks --all | grep -E "test.*UnitTest|:test"`
+2. Identify common tasks:
+   - `:app:testDebugUnitTest`
+   - `testDebugUnitTest` (root aggregation if present)
+   - flavors: `test<Flavor><BuildType>UnitTest`
+
+## 2) Run unit tests
+- First attempt (fast, useful output):
+  - `./gradlew testDebugUnitTest --stacktrace`
+- If multi-module, run the failing module task explicitly:
+  - `./gradlew :<module>:testDebugUnitTest --stacktrace`
+
+## 3) Collect evidence
+- Always locate HTML report paths, e.g.:
+  - `<module>/build/reports/tests/`
+- Extract:
+  - failing test class/method
+  - assertion message
+  - stacktrace root cause
+
+## 4) Fix strategy
+- Prefer fixing production code bugs vs weakening tests.
+- If test is flaky:
+  - remove time dependence
+  - isolate coroutines/dispatchers
+  - mock IO/network
+- Keep changes minimal and explain tradeoffs.
+
+## 5) Re-run and confirm
+- Re-run the exact same command.
+- If CI uses a different variant, also run that variant.
+
+# Output format
+- Command(s) executed
+- Failures summary (table)
+- Root cause
+- Patch + why
+- Validation commands

--- a/.github/skills/android-unit-testing/scripts/run_unit_tests.sh
+++ b/.github/skills/android-unit-testing/scripts/run_unit_tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   ./github/skills/android-unit-testing/scripts/run_unit_tests.sh [gradle_task]
+# Example:
+#   ./.../run_unit_tests.sh testDebugUnitTest
+#   ./.../run_unit_tests.sh :app:testDemoDebugUnitTest
+
+TASK="${1:-testDebugUnitTest}"
+
+echo "==> Running: ./gradlew ${TASK} --stacktrace"
+./gradlew "${TASK}" --stacktrace
+
+echo
+echo "==> Reports (common locations):"
+echo "  - <module>/build/reports/tests/"
+echo "  - <module>/build/test-results/"

--- a/.github/skills/dependency-upgrade-with-changelog/SKILL.md
+++ b/.github/skills/dependency-upgrade-with-changelog/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: dependency-upgrade-with-changelog
+description: Use when upgrading dependencies. Produces safe upgrade plan, changelog links, and validation steps.
+---
+
+# Approach
+1. Identify current version and target version (minor/patch first, then major).
+2. Check breaking changes:
+   - release notes / migration docs
+   - deprecated APIs used in repo (search)
+3. Update:
+   - one major at a time
+   - keep changes minimal
+4. Validation:
+   - run unit tests + lint
+   - smoke-check key flows
+
+# Output
+- Upgrade plan (steps)
+- Risk items + mitigations
+- Final diff + validation commands

--- a/.github/skills/github-actions-failure-debugging/SKILL.md
+++ b/.github/skills/github-actions-failure-debugging/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: github-actions-failure-debugging
+description: Debug guide for failing GitHub Actions workflows. Use when CI fails, tests fail on Actions, or logs show exit code != 0.
+---
+
+# Goals
+- Identify the *first* failing step and the real root cause (not the cascade).
+- Produce a minimal fix (workflow or code) and re-run checks.
+
+# Procedure
+1. Find the failing workflow run and the failing job/step. Extract:
+   - runner OS, language/runtime versions, cache usage
+   - exact command that failed
+2. Classify failure:
+   - build tool / dependency resolution
+   - test failure
+   - lint/static analysis
+   - auth/permissions/secrets
+3. Reproduce locally when possible:
+   - use the same command as the workflow
+   - if not possible, provide a deterministic reproduction plan.
+4. Fix strategy:
+   - prefer smallest change
+   - avoid disabling checks unless justified
+5. Verification:
+   - ensure job matrix still passes
+   - update docs if workflow usage changed
+
+# Output format
+- Root cause (1-2 sentences)
+- Evidence (log excerpt references)
+- Fix diff + why it works
+- How to validate (exact commands)

--- a/.github/skills/pr-review-checklist/SKILL.md
+++ b/.github/skills/pr-review-checklist/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: pr-review-checklist
+description: Use when asked to review a PR, propose review comments, or prepare a merge checklist.
+---
+
+# Review checklist
+## Correctness
+- Does the change match the issue/user story?
+- Edge cases, nullability, threading, lifecycle.
+
+## Tests
+- New/updated unit tests exist for logic changes
+- Flaky patterns avoided (timers, real network, device state)
+
+## Architecture
+- Boundaries respected (UI/Domain/Data)
+- DI scope correct
+- Side effects isolated
+
+## Android specifics
+- Compose: state hoisting, recomposition safety, stable types
+- Coroutines: dispatcher correctness, structured concurrency
+- Resources: localization, accessibility
+
+# Deliverable
+- 5-10 review comments grouped by severity: [must] [should] [nit]
+- A merge-ready checklist (tests, docs, rollout notes)


### PR DESCRIPTION
### Motivation
- Centralize repository guidance for GitHub Copilot and normalize skill documents for tooling/automation.
- Provide explicit, repeatable steps for running and diagnosing Android JVM unit tests.
- Make it easier to discover recommended Gradle commands and test report locations.

### Description
- Add a repository overview at `.github/copilot-instructions.md` with quickstart, architecture, and CI expectations.
- Add normalized skill files under `.github/skills/` for `android-camera`, `android-unit-testing`, `dependency-upgrade-with-changelog`, `github-actions-failure-debugging`, and `pr-review-checklist`.
- Add an executable helper script at `.github/skills/android-unit-testing/scripts/run_unit_tests.sh` that runs `./gradlew <task> --stacktrace` and defaults to `testDebugUnitTest`.
- Set the script as executable and commit the new files to the repository.

### Testing
- No automated tests or CI jobs were executed for these documentation and helper-script changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960bb0aa2208330892d529a3db64713)