### PR TITLE
Remove deprecated `org.jetbrains.kotlin.android` plugin from app/build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.plugin.compose'
     id("com.google.gms.google-services")
     id 'com.google.dagger.hilt.android'


### PR DESCRIPTION
### Motivation
- Fix the GitHub Actions build failure caused by the `org.jetbrains.kotlin.android` plugin which is deprecated when using AGP 9 and is no longer required because Kotlin is built into AGP 9.

### Description
- Remove the `id 'org.jetbrains.kotlin.android'` line from the `plugins` block in `app/build.gradle` so the project relies on AGP's built-in Kotlin support.

### Testing
- No automated tests were run as part of this change; commit should unblock the CI build so please re-run the GitHub Actions pipeline to verify the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888bf7c8ec8330888dfa5fa191e44c)