### PR TITLE
Use DSL-style kapt dependency declarations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     
     // Hilt
     implementation 'com.google.dagger:hilt-android:2.59'
-    kapt 'com.google.dagger:hilt-android-compiler:2.59'
+    kapt("com.google.dagger:hilt-android-compiler:2.59")
     implementation 'androidx.hilt:hilt-navigation-compose:1.3.0'
     
     // ARCore
@@ -171,14 +171,14 @@ dependencies {
     // Add missing MockK dependency for tests that use io.mockk.*
     testImplementation 'io.mockk:mockk:1.14.7'
 
-    kaptTest 'com.google.dagger:hilt-android-compiler:2.59'
+    kaptTest("com.google.dagger:hilt-android-compiler:2.59")
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
     androidTestImplementation 'androidx.test:rules:1.7.0'
     androidTestImplementation 'androidx.test:runner:1.7.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     androidTestImplementation 'com.google.dagger:hilt-android-testing:2.59'
-    kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.59'
+    kaptAndroidTest("com.google.dagger:hilt-android-compiler:2.59")
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
     implementation "org.jetbrains.kotlin:kotlin-test:2.3.0"


### PR DESCRIPTION
### Motivation
- Standardize dependency declarations in the `app` module build script by switching kapt entries to the DSL-style call syntax to avoid mixed notation and align with modern Gradle Kotlin/Groovy DSL usage.

### Description
- Updated `app/build.gradle` to replace `kapt 'com.google.dagger:hilt-android-compiler:2.59'`, `kaptTest 'com.google.dagger:hilt-android-compiler:2.59'`, and `kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.59'` with `kapt("com.google.dagger:hilt-android-compiler:2.59")`, `kaptTest("com.google.dagger:hilt-android-compiler:2.59")`, and `kaptAndroidTest("com.google.dagger:hilt-android-compiler:2.59")` respectively in `app/build.gradle`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69894de7c3e483309cafb655f75df197)