### PR TITLE
refactor: 優先度B - Renderer/VRMキャッシュ/権限判定を分離

### DIFF
--- a/app/src/main/java/com/example/vtubercamera/data/vrm/FilamentARRenderer.kt
+++ b/app/src/main/java/com/example/vtubercamera/data/vrm/FilamentARRenderer.kt
@@ -6,7 +6,6 @@ import android.opengl.GLES20
 import android.opengl.Matrix
 import android.util.Log
 import android.view.Surface
-import androidx.core.graphics.createBitmap
 import com.example.vtubercamera.data.vrm.math.Transform
 import com.google.android.filament.Camera
 import com.google.android.filament.Engine
@@ -73,7 +72,9 @@ class FilamentARRenderer @Inject constructor(
     private val materialManager: FilamentMaterialManager,
     private val textureManager: FilamentTextureManager,
     private val lightingSystem: LightingSystem,
-    private val shadowSystem: ShadowSystem
+    private val shadowSystem: ShadowSystem,
+    private val lightingApplier: FilamentLightingApplier,
+    private val frameCaptureService: FilamentFrameCaptureService,
 ) : ARRenderer {
 
     companion object {
@@ -258,27 +259,12 @@ class FilamentARRenderer @Inject constructor(
 
         if (!isInitialized) return
 
-        try {
-            // Update lighting system with environment lighting
-            lightingSystem.updateEnvironmentLighting(lightEstimate)
-
-            // Update shadow system with new lighting
-            val cameraPosition = floatArrayOf(0f, 0f, 5f)
-            val cameraTarget = floatArrayOf(0f, 0f, 0f)
-            shadowSystem.updateShadows(
-                lightingSystem.finalLightingParameters.value,
-                cameraPosition,
-                cameraTarget
-            )
-
-            // TODO: Apply lighting to Filament scene
-            // updateSceneLighting(lightEstimate)
-
-            Log.d(TAG, "Updated lighting - Intensity: ${lightEstimate.pixelIntensity}")
-
-        } catch (e: Exception) {
-            Log.e(TAG, "Error setting lighting", e)
-        }
+        lightingApplier.applyLighting(
+            tag = TAG,
+            lightingSystem = lightingSystem,
+            shadowSystem = shadowSystem,
+            lightEstimate = lightEstimate,
+        )
     }
 
     override fun captureFrame(): Bitmap {
@@ -292,13 +278,11 @@ class FilamentARRenderer @Inject constructor(
         }
 
         try {
-            // TODO: Capture frame from Filament renderer
-            // return captureFilamentFrame()
-
-            // Placeholder implementation
-            Log.d(TAG, "Capturing frame (placeholder)")
-            return createBitmap(viewportWidth, viewportHeight)
-
+            return frameCaptureService.capturePlaceholder(
+                tag = TAG,
+                width = viewportWidth,
+                height = viewportHeight,
+            )
         } catch (e: Exception) {
             Log.e(TAG, "Error capturing frame", e)
             throw ARError.RenderingError("Failed to capture frame: ${e.message}")

--- a/app/src/main/java/com/example/vtubercamera/data/vrm/FilamentFrameCaptureService.kt
+++ b/app/src/main/java/com/example/vtubercamera/data/vrm/FilamentFrameCaptureService.kt
@@ -1,0 +1,13 @@
+package com.example.vtubercamera.data.vrm
+
+import android.graphics.Bitmap
+import android.util.Log
+import androidx.core.graphics.createBitmap
+import javax.inject.Inject
+
+class FilamentFrameCaptureService @Inject constructor() {
+    fun capturePlaceholder(tag: String, width: Int, height: Int): Bitmap {
+        Log.d(tag, "Capturing frame (placeholder)")
+        return createBitmap(width, height)
+    }
+}

--- a/app/src/main/java/com/example/vtubercamera/data/vrm/FilamentLightingApplier.kt
+++ b/app/src/main/java/com/example/vtubercamera/data/vrm/FilamentLightingApplier.kt
@@ -1,0 +1,30 @@
+package com.example.vtubercamera.data.vrm
+
+import android.util.Log
+import com.google.ar.core.LightEstimate
+import javax.inject.Inject
+
+class FilamentLightingApplier @Inject constructor() {
+    fun applyLighting(
+        tag: String,
+        lightingSystem: LightingSystem,
+        shadowSystem: ShadowSystem,
+        lightEstimate: LightEstimate,
+    ) {
+        try {
+            lightingSystem.updateEnvironmentLighting(lightEstimate)
+
+            val cameraPosition = floatArrayOf(0f, 0f, 5f)
+            val cameraTarget = floatArrayOf(0f, 0f, 0f)
+            shadowSystem.updateShadows(
+                lightingSystem.finalLightingParameters.value,
+                cameraPosition,
+                cameraTarget,
+            )
+
+            Log.d(tag, "Updated lighting - Intensity: ${lightEstimate.pixelIntensity}")
+        } catch (e: Exception) {
+            Log.e(tag, "Error setting lighting", e)
+        }
+    }
+}

--- a/app/src/main/java/com/example/vtubercamera/data/vrm/VRMAssetCache.kt
+++ b/app/src/main/java/com/example/vtubercamera/data/vrm/VRMAssetCache.kt
@@ -1,0 +1,71 @@
+package com.example.vtubercamera.data.vrm
+
+class VRMAssetCache {
+    private val modelCache = mutableMapOf<String, VRMModel>()
+    private val meshCache = mutableMapOf<String, MeshData>()
+    private val textureCache = mutableMapOf<String, TextureData>()
+    private val expressionCache = mutableMapOf<String, ExpressionData>()
+    private val poseCache = mutableMapOf<String, PoseData>()
+
+    fun putModel(modelId: String, model: VRMModel) {
+        modelCache[modelId] = model
+    }
+
+    fun getModel(modelId: String): VRMModel? = modelCache[modelId]
+
+    fun putMesh(modelId: String, meshData: MeshData) {
+        meshCache[modelId] = meshData
+    }
+
+    fun getMesh(modelId: String): MeshData? = meshCache[modelId]
+
+    fun putTexture(modelId: String, textureData: TextureData) {
+        textureCache[modelId] = textureData
+    }
+
+    fun getTexture(modelId: String): TextureData? = textureCache[modelId]
+
+    fun putExpression(modelId: String, expressionData: ExpressionData) {
+        expressionCache[modelId] = expressionData
+    }
+
+    fun getExpression(modelId: String): ExpressionData? = expressionCache[modelId]
+
+    fun putPose(modelId: String, poseData: PoseData) {
+        poseCache[modelId] = poseData
+    }
+
+    fun getPose(modelId: String): PoseData? = poseCache[modelId]
+
+    fun clearModel(modelId: String) {
+        modelCache.remove(modelId)
+        meshCache.remove(modelId)
+        textureCache.remove(modelId)
+        expressionCache.remove(modelId)
+        poseCache.remove(modelId)
+    }
+
+    fun clearAll() {
+        modelCache.clear()
+        meshCache.clear()
+        textureCache.clear()
+        expressionCache.clear()
+        poseCache.clear()
+    }
+
+    fun memoryStats(): VRMMemoryStats {
+        val modelMemory = modelCache.values.sumOf { it.getEstimatedMemoryUsage() }
+        val meshMemory = meshCache.values.sumOf { it.getMemoryUsage() }
+        val textureMemory = textureCache.values.sumOf { it.totalMemoryUsage }
+
+        return VRMMemoryStats(
+            totalMemoryUsage = modelMemory + meshMemory + textureMemory,
+            modelMemory = modelMemory,
+            meshMemory = meshMemory,
+            textureMemory = textureMemory,
+            cachedModels = modelCache.size,
+            cachedMeshes = meshCache.size,
+            cachedTextures = textureCache.size,
+        )
+    }
+}

--- a/app/src/main/java/com/example/vtubercamera/data/vrm/VRMManager.kt
+++ b/app/src/main/java/com/example/vtubercamera/data/vrm/VRMManager.kt
@@ -26,12 +26,7 @@ class VRMManager @Inject constructor(
     private val expressionLoader = VRMExpressionLoader()
     private val poseLoader = VRMPoseLoader()
     
-    // Simple in-memory cache
-    private val modelCache = mutableMapOf<String, VRMModel>()
-    private val meshCache = mutableMapOf<String, MeshData>()
-    private val textureCache = mutableMapOf<String, TextureData>()
-    private val expressionCache = mutableMapOf<String, ExpressionData>()
-    private val poseCache = mutableMapOf<String, PoseData>()
+    private val assetCache = VRMAssetCache()
     
     /**
      * Load complete VRM model with all components
@@ -55,7 +50,7 @@ class VRMManager @Inject constructor(
             modelResult.fold(
                 onSuccess = { vrmModel ->
                     val modelId = vrmModel.id
-                    modelCache[modelId] = vrmModel
+                    assetCache.putModel(modelId, vrmModel)
                     
                     // Load detailed components
                     emit(VRMLoadingProgress.LoadingMesh(0.3f))
@@ -92,7 +87,7 @@ class VRMManager @Inject constructor(
      * Load mesh data for VRM model
      */
     private suspend fun loadMeshData(modelId: String, vrmModel: VRMModel): MeshData = withContext(Dispatchers.IO) {
-        meshCache[modelId]?.let { return@withContext it }
+        assetCache.getMesh(modelId)?.let { return@withContext it }
         
         try {
             // Parse mesh data from VRM binary data
@@ -101,7 +96,7 @@ class VRMManager @Inject constructor(
                 binaryData = vrmModel.meshData
             )
             
-            meshCache[modelId] = meshData
+            assetCache.putMesh(modelId, meshData)
             meshData
         } catch (_: Exception) {
             MeshData.empty()
@@ -112,7 +107,7 @@ class VRMManager @Inject constructor(
      * Load texture data for VRM model
      */
     private suspend fun loadTextureData(modelId: String, vrmModel: VRMModel): TextureData = withContext(Dispatchers.IO) {
-        textureCache[modelId]?.let { return@withContext it }
+        assetCache.getTexture(modelId)?.let { return@withContext it }
         
         try {
             val textureData = textureExtractor.extractTextures(
@@ -121,7 +116,7 @@ class VRMManager @Inject constructor(
                 fullFileData = vrmModel.meshData
             )
             
-            textureCache[modelId] = textureData
+            assetCache.putTexture(modelId, textureData)
             textureData
         } catch (_: Exception) {
             TextureData.empty()
@@ -132,10 +127,10 @@ class VRMManager @Inject constructor(
      * Load expression data for VRM model
      */
     private suspend fun loadExpressionData(modelId: String, vrmModel: VRMModel): ExpressionData = withContext(Dispatchers.IO) {
-        expressionCache[modelId]?.let { return@withContext it }
+        assetCache.getExpression(modelId)?.let { return@withContext it }
         
         try {
-            val meshData = meshCache[modelId] ?: MeshData.empty()
+            val meshData = assetCache.getMesh(modelId) ?: MeshData.empty()
             val vrmExtension = extractVRMExtension(vrmModel.meshData)
             
             val expressionData = if (vrmExtension != null) {
@@ -150,7 +145,7 @@ class VRMManager @Inject constructor(
                 )
             }
             
-            expressionCache[modelId] = expressionData
+            assetCache.putExpression(modelId, expressionData)
             expressionData
         } catch (_: Exception) {
             ExpressionData.empty()
@@ -161,7 +156,7 @@ class VRMManager @Inject constructor(
      * Load pose data for VRM model
      */
     private suspend fun loadPoseData(modelId: String, vrmModel: VRMModel): PoseData = withContext(Dispatchers.IO) {
-        poseCache[modelId]?.let { return@withContext it }
+        assetCache.getPose(modelId)?.let { return@withContext it }
         
         try {
             val gltfJson = parseJsonFromVRM(vrmModel.meshData)
@@ -173,7 +168,7 @@ class VRMManager @Inject constructor(
                 vrmExtension = vrmExtension
             )
             
-            poseCache[modelId] = poseData
+            assetCache.putPose(modelId, poseData)
             poseData
         } catch (_: Exception) {
             // Use the poses from the model
@@ -190,67 +185,47 @@ class VRMManager @Inject constructor(
     /**
      * Get cached VRM model
      */
-    fun getCachedModel(modelId: String): VRMModel? = modelCache[modelId]
+    fun getCachedModel(modelId: String): VRMModel? = assetCache.getModel(modelId)
     
     /**
      * Get cached mesh data
      */
-    fun getCachedMeshData(modelId: String): MeshData? = meshCache[modelId]
+    fun getCachedMeshData(modelId: String): MeshData? = assetCache.getMesh(modelId)
     
     /**
      * Get cached texture data
      */
-    fun getCachedTextureData(modelId: String): TextureData? = textureCache[modelId]
+    fun getCachedTextureData(modelId: String): TextureData? = assetCache.getTexture(modelId)
     
     /**
      * Get cached expression data
      */
-    fun getCachedExpressionData(modelId: String): ExpressionData? = expressionCache[modelId]
+    fun getCachedExpressionData(modelId: String): ExpressionData? = assetCache.getExpression(modelId)
     
     /**
      * Get cached pose data
      */
-    fun getCachedPoseData(modelId: String): PoseData? = poseCache[modelId]
+    fun getCachedPoseData(modelId: String): PoseData? = assetCache.getPose(modelId)
     
     /**
      * Clear cache for specific model
      */
     fun clearModelCache(modelId: String) {
-        modelCache.remove(modelId)
-        meshCache.remove(modelId)
-        textureCache.remove(modelId)
-        expressionCache.remove(modelId)
-        poseCache.remove(modelId)
+        assetCache.clearModel(modelId)
     }
     
     /**
      * Clear all caches
      */
     fun clearAllCaches() {
-        modelCache.clear()
-        meshCache.clear()
-        textureCache.clear()
-        expressionCache.clear()
-        poseCache.clear()
+        assetCache.clearAll()
     }
     
     /**
      * Get memory usage statistics
      */
     fun getMemoryStats(): VRMMemoryStats {
-        val modelMemory = modelCache.values.sumOf { it.getEstimatedMemoryUsage() }
-        val meshMemory = meshCache.values.sumOf { it.getMemoryUsage() }
-        val textureMemory = textureCache.values.sumOf { it.totalMemoryUsage }
-        
-        return VRMMemoryStats(
-            totalMemoryUsage = modelMemory + meshMemory + textureMemory,
-            modelMemory = modelMemory,
-            meshMemory = meshMemory,
-            textureMemory = textureMemory,
-            cachedModels = modelCache.size,
-            cachedMeshes = meshCache.size,
-            cachedTextures = textureCache.size
-        )
+        return assetCache.memoryStats()
     }
     
     /**
@@ -280,10 +255,10 @@ class VRMManager @Inject constructor(
     private fun createCompleteVRMData(modelId: String, vrmModel: VRMModel): CompleteVRMData {
         return CompleteVRMData(
             model = vrmModel,
-            meshData = meshCache[modelId] ?: MeshData.empty(),
-            textureData = textureCache[modelId] ?: TextureData.empty(),
-            expressionData = expressionCache[modelId] ?: ExpressionData.empty(),
-            poseData = poseCache[modelId] ?: PoseData.empty()
+            meshData = assetCache.getMesh(modelId) ?: MeshData.empty(),
+            textureData = assetCache.getTexture(modelId) ?: TextureData.empty(),
+            expressionData = assetCache.getExpression(modelId) ?: ExpressionData.empty(),
+            poseData = assetCache.getPose(modelId) ?: PoseData.empty()
         )
     }
     

--- a/app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt
+++ b/app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt
@@ -6,7 +6,6 @@ import com.example.vtubercamera.data.vrm.ARCameraState
 import com.example.vtubercamera.data.vrm.ARError
 import com.example.vtubercamera.data.vrm.ARSessionState
 import com.example.vtubercamera.data.vrm.TrackingState
-import com.example.vtubercamera.data.vrm.math.Transform
 import com.example.vtubercamera.domain.camera.UiStateProvider
 import com.example.vtubercamera.domain.camera.UiStateUpdater
 import kotlinx.coroutines.CoroutineScope
@@ -25,6 +24,7 @@ class ARFeature @Inject constructor(
         scope: CoroutineScope,
         updateUiState: UiStateUpdater,
         uiStateProvider: UiStateProvider,
+        onTrackingStateChanged: (TrackingState) -> Unit,
         startSession: suspend (
             onSessionReady: () -> Unit,
             onError: (ARError) -> Unit,
@@ -55,7 +55,7 @@ class ARFeature @Inject constructor(
                         observeARStates(
                             scope = scope,
                             updateUiState = updateUiState,
-                            uiStateProvider = uiStateProvider,
+                            onTrackingStateChanged = onTrackingStateChanged,
                         )
                     },
                     { error ->
@@ -65,6 +65,7 @@ class ARFeature @Inject constructor(
                             scope = scope,
                             updateUiState = updateUiState,
                             uiStateProvider = uiStateProvider,
+                            resetAvatarState = {},
                         )
                     }
                 )
@@ -77,6 +78,7 @@ class ARFeature @Inject constructor(
                     scope = scope,
                     updateUiState = updateUiState,
                     uiStateProvider = uiStateProvider,
+                    resetAvatarState = {},
                 )
             }
         }
@@ -86,6 +88,7 @@ class ARFeature @Inject constructor(
         scope: CoroutineScope,
         updateUiState: UiStateUpdater,
         uiStateProvider: UiStateProvider,
+        resetAvatarState: () -> Unit,
     ) {
         if (!uiStateProvider().isARMode) {
             Log.d(TAG, "AR mode already disabled")
@@ -98,7 +101,6 @@ class ARFeature @Inject constructor(
 
                 arRepository.destroySession()
 
-                val currentAvatarState = uiStateProvider().avatarState
                 updateUiState {
                     copy(
                         ar = ar.copy(
@@ -107,18 +109,12 @@ class ARFeature @Inject constructor(
                             arCameraState = ARCameraState.default(),
                             arError = null,
                         ),
-                        avatar = avatar.copy(
-                            avatarState = currentAvatarState.copy(
-                                transform = Transform.identity(),
-                                isVisible = false,
-                            ),
-                            avatarTransform = Transform.identity(),
-                        ),
                         camera = camera.copy(
                             needsCameraRebind = true,
                         )
                     )
                 }
+                resetAvatarState()
 
                 Log.d(TAG, "AR mode disabled")
             } catch (e: Exception) {
@@ -131,6 +127,8 @@ class ARFeature @Inject constructor(
         scope: CoroutineScope,
         updateUiState: UiStateUpdater,
         uiStateProvider: UiStateProvider,
+        onTrackingStateChanged: (TrackingState) -> Unit,
+        resetAvatarState: () -> Unit,
         startSession: suspend (
             onSessionReady: () -> Unit,
             onError: (ARError) -> Unit,
@@ -141,12 +139,14 @@ class ARFeature @Inject constructor(
                 scope = scope,
                 updateUiState = updateUiState,
                 uiStateProvider = uiStateProvider,
+                resetAvatarState = resetAvatarState,
             )
         } else {
             enableARMode(
                 scope = scope,
                 updateUiState = updateUiState,
                 uiStateProvider = uiStateProvider,
+                onTrackingStateChanged = onTrackingStateChanged,
                 startSession = startSession,
             )
         }
@@ -155,7 +155,7 @@ class ARFeature @Inject constructor(
     private fun observeARStates(
         scope: CoroutineScope,
         updateUiState: UiStateUpdater,
-        uiStateProvider: UiStateProvider,
+        onTrackingStateChanged: (TrackingState) -> Unit,
     ) {
         scope.launch {
             arRepository.sessionState.collect { sessionState ->
@@ -172,19 +172,7 @@ class ARFeature @Inject constructor(
         scope.launch {
             arRepository.trackingState.collect { trackingState ->
                 Log.d(TAG, "AR tracking state changed: $trackingState")
-                val currentState = uiStateProvider()
-                if (currentState.avatarState.model != null) {
-                    val shouldShow = trackingState == TrackingState.TRACKING
-                    if (currentState.avatarState.isVisible != shouldShow) {
-                        updateUiState {
-                            copy(
-                                avatar = avatar.copy(
-                                    avatarState = currentState.avatarState.copy(isVisible = shouldShow)
-                                )
-                            )
-                        }
-                    }
-                }
+                onTrackingStateChanged(trackingState)
             }
         }
     }

--- a/app/src/main/java/com/example/vtubercamera/domain/camera/CameraCaptureFeature.kt
+++ b/app/src/main/java/com/example/vtubercamera/domain/camera/CameraCaptureFeature.kt
@@ -1,0 +1,45 @@
+package com.example.vtubercamera.domain.camera
+
+import androidx.camera.core.ImageCapture
+import com.example.vtubercamera.data.ARPhotoMetadata
+import com.example.vtubercamera.data.CameraRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class CameraCaptureFeature @Inject constructor(
+    private val cameraRepository: CameraRepository,
+) {
+
+    fun capturePhoto(
+        imageCapture: ImageCapture,
+        scope: CoroutineScope,
+        onPhotoSaved: (android.net.Uri) -> Unit,
+        onError: (String) -> Unit,
+    ) {
+        scope.launch {
+            cameraRepository.capturePhoto(
+                imageCapture = imageCapture,
+                onPhotoSaved = onPhotoSaved,
+                onError = onError,
+            )
+        }
+    }
+
+    fun captureARPhoto(
+        imageCapture: ImageCapture,
+        arMetadata: ARPhotoMetadata,
+        scope: CoroutineScope,
+        onPhotoSaved: (android.net.Uri) -> Unit,
+        onError: (String) -> Unit,
+    ) {
+        scope.launch {
+            cameraRepository.captureARPhoto(
+                imageCapture = imageCapture,
+                arMetadata = arMetadata,
+                onPhotoSaved = onPhotoSaved,
+                onError = onError,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/vtubercamera/domain/camera/CameraCaptureFeature.kt
+++ b/app/src/main/java/com/example/vtubercamera/domain/camera/CameraCaptureFeature.kt
@@ -18,11 +18,15 @@ class CameraCaptureFeature @Inject constructor(
         onError: (String) -> Unit,
     ) {
         scope.launch {
-            cameraRepository.capturePhoto(
-                imageCapture = imageCapture,
-                onPhotoSaved = onPhotoSaved,
-                onError = onError,
-            )
+            try {
+                cameraRepository.capturePhoto(
+                    imageCapture = imageCapture,
+                    onPhotoSaved = onPhotoSaved,
+                    onError = onError,
+                )
+            } catch (e: Exception) {
+                onError(e.message ?: "Failed to capture photo. Please try again.")
+            }
         }
     }
 
@@ -34,12 +38,16 @@ class CameraCaptureFeature @Inject constructor(
         onError: (String) -> Unit,
     ) {
         scope.launch {
-            cameraRepository.captureARPhoto(
-                imageCapture = imageCapture,
-                arMetadata = arMetadata,
-                onPhotoSaved = onPhotoSaved,
-                onError = onError,
-            )
+            try {
+                cameraRepository.captureARPhoto(
+                    imageCapture = imageCapture,
+                    arMetadata = arMetadata,
+                    onPhotoSaved = onPhotoSaved,
+                    onError = onError,
+                )
+            } catch (e: Exception) {
+                onError(e.message ?: "Failed to capture AR photo. Please try again.")
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/vtubercamera/managers/ARPermissionManager.kt
+++ b/app/src/main/java/com/example/vtubercamera/managers/ARPermissionManager.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
@@ -14,7 +13,6 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.google.ar.core.ArCoreApk
@@ -27,7 +25,8 @@ import kotlin.coroutines.resume
 
 @Singleton
 class ARPermissionManager @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val permissionGateway: PermissionGateway,
 ) : DefaultLifecycleObserver {
     
     private companion object {
@@ -107,7 +106,7 @@ class ARPermissionManager @Inject constructor(
         
         requiredARPermissions.forEach { permission ->
             when {
-                ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED -> {
+                !permissionGateway.isPermissionGranted(permission) -> {
                     deniedPermissions.add(permission)
                     
                     currentActivity?.let { activity ->
@@ -146,7 +145,7 @@ class ARPermissionManager @Inject constructor(
         permissionCallback = callback
         
         val permissionsToRequest = requiredARPermissions.filter { permission ->
-            ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED
+            !permissionGateway.isPermissionGranted(permission)
         }.toTypedArray()
         
         if (permissionsToRequest.isNotEmpty()) {
@@ -164,7 +163,7 @@ class ARPermissionManager @Inject constructor(
     
     fun checkOptionalPermissions(): Map<String, Boolean> {
         return optionalARPermissions.associateWith { permission ->
-            ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+            permissionGateway.isPermissionGranted(permission)
         }
     }
     
@@ -177,7 +176,7 @@ class ARPermissionManager @Inject constructor(
         }
         
         val deniedPermissions = validPermissions.filter { permission ->
-            ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED
+            !permissionGateway.isPermissionGranted(permission)
         }
         
         if (deniedPermissions.isEmpty()) {
@@ -369,27 +368,15 @@ class ARPermissionManager @Inject constructor(
     fun hasAllRequiredPermissions(): Boolean = checkARPermissions().granted
     
     fun hasCameraPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            context, 
-            Manifest.permission.CAMERA
-        ) == PackageManager.PERMISSION_GRANTED
+        return permissionGateway.isPermissionGranted(Manifest.permission.CAMERA)
     }
     
     fun hasLocationPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            context, 
-            Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED ||
-        ContextCompat.checkSelfPermission(
-            context, 
-            Manifest.permission.ACCESS_COARSE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED
+        return permissionGateway.isPermissionGranted(Manifest.permission.ACCESS_FINE_LOCATION) ||
+            permissionGateway.isPermissionGranted(Manifest.permission.ACCESS_COARSE_LOCATION)
     }
     
     fun hasAudioPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            context, 
-            Manifest.permission.RECORD_AUDIO
-        ) == PackageManager.PERMISSION_GRANTED
+        return permissionGateway.isPermissionGranted(Manifest.permission.RECORD_AUDIO)
     }
 }

--- a/app/src/main/java/com/example/vtubercamera/managers/PermissionGateway.kt
+++ b/app/src/main/java/com/example/vtubercamera/managers/PermissionGateway.kt
@@ -1,0 +1,26 @@
+package com.example.vtubercamera.managers
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import com.example.vtubercamera.utils.PermissionUtils
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PermissionGateway @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    fun hasCameraPermission(): Boolean = PermissionUtils.hasCameraPermission(context)
+
+    fun hasMediaPermissions(): Boolean = PermissionUtils.hasMediaPermissions(context)
+
+    fun hasPartialMediaAccess(): Boolean = PermissionUtils.hasPartialMediaAccess(context)
+
+    fun getRequiredMediaPermissions(): Array<String> = PermissionUtils.getRequiredMediaPermissions()
+
+    fun isPermissionGranted(permission: String): Boolean {
+        return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/app/src/main/java/com/example/vtubercamera/managers/PermissionManager.kt
+++ b/app/src/main/java/com/example/vtubercamera/managers/PermissionManager.kt
@@ -1,20 +1,17 @@
 package com.example.vtubercamera.managers
 
-import android.content.Context
-import com.example.vtubercamera.utils.PermissionUtils
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class PermissionManager @Inject constructor(
-    @ApplicationContext private val context: Context
+    private val permissionGateway: PermissionGateway,
 ) {
-    fun hasCameraPermission(): Boolean = PermissionUtils.hasCameraPermission(context)
-    
-    fun hasMediaPermissions(): Boolean = PermissionUtils.hasMediaPermissions(context)
-    
-    fun hasPartialMediaAccess(): Boolean = PermissionUtils.hasPartialMediaAccess(context)
-    
-    fun getRequiredMediaPermissions(): Array<String> = PermissionUtils.getRequiredMediaPermissions()
+    fun hasCameraPermission(): Boolean = permissionGateway.hasCameraPermission()
+
+    fun hasMediaPermissions(): Boolean = permissionGateway.hasMediaPermissions()
+
+    fun hasPartialMediaAccess(): Boolean = permissionGateway.hasPartialMediaAccess()
+
+    fun getRequiredMediaPermissions(): Array<String> = permissionGateway.getRequiredMediaPermissions()
 }

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -144,8 +144,8 @@ fun CameraScreen(
         context = context,
         onPartialAccessDetected = { showPartialAccessDialog = true },
     )
-    val hasCameraPermission = permissionState.hasCameraPermission
-    val hasMediaPermissions = permissionState.hasMediaPermissions
+    val hasCameraPermission = PermissionUtils.hasCameraPermission(context)
+    val hasMediaPermissions = PermissionUtils.hasMediaPermissions(context)
 
     LaunchedEffect(hasMediaPermissions) {
         if (hasMediaPermissions) {

--- a/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt
@@ -140,44 +140,12 @@ fun CameraScreen(
     var showLensSwitchFeedback by remember { mutableStateOf(false) }
     var lensSwitchFeedbackName by remember { mutableStateOf("") }
 
-    var hasCameraPermission by remember {
-        mutableStateOf(
-            PermissionUtils.hasCameraPermission(context)
-        )
-    }
-    var hasMediaPermissions by remember {
-        mutableStateOf(
-            PermissionUtils.hasMediaPermissions(context)
-        )
-    }
-
-    val cameraPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission(),
-        onResult = { granted ->
-            hasCameraPermission = granted
-        }
+    val permissionState = rememberCameraPermissionState(
+        context = context,
+        onPartialAccessDetected = { showPartialAccessDialog = true },
     )
-    val mediaPermissionsLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestMultiplePermissions(),
-        onResult = { permissions ->
-            hasMediaPermissions = permissions.values.all { it }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                val hasPartialAccess = PermissionUtils.hasPartialMediaAccess(context)
-                if (hasPartialAccess && !permissions[Manifest.permission.READ_MEDIA_IMAGES]!!) {
-                    showPartialAccessDialog = true
-                }
-            }
-        }
-    )
-
-    LaunchedEffect(Unit) {
-        if (!hasCameraPermission) {
-            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
-        }
-        if (!hasMediaPermissions) {
-            mediaPermissionsLauncher.launch(PermissionUtils.getRequiredMediaPermissions())
-        }
-    }
+    val hasCameraPermission = permissionState.hasCameraPermission
+    val hasMediaPermissions = permissionState.hasMediaPermissions
 
     LaunchedEffect(hasMediaPermissions) {
         if (hasMediaPermissions) {
@@ -376,6 +344,51 @@ fun CameraScreen(
 
 // end of CameraScreen
 
+
+private data class CameraPermissionState(
+    val hasCameraPermission: Boolean,
+    val hasMediaPermissions: Boolean,
+)
+
+@Composable
+private fun rememberCameraPermissionState(
+    context: android.content.Context,
+    onPartialAccessDetected: () -> Unit,
+): CameraPermissionState {
+    var hasCameraPermission by remember { mutableStateOf(PermissionUtils.hasCameraPermission(context)) }
+    var hasMediaPermissions by remember { mutableStateOf(PermissionUtils.hasMediaPermissions(context)) }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = { granted -> hasCameraPermission = granted }
+    )
+    val mediaPermissionsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+        onResult = { permissions ->
+            hasMediaPermissions = permissions.values.all { it }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                val hasPartialAccess = PermissionUtils.hasPartialMediaAccess(context)
+                if (hasPartialAccess && permissions[Manifest.permission.READ_MEDIA_IMAGES] == false) {
+                    onPartialAccessDetected()
+                }
+            }
+        }
+    )
+
+    LaunchedEffect(Unit) {
+        if (!hasCameraPermission) {
+            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+        if (!hasMediaPermissions) {
+            mediaPermissionsLauncher.launch(PermissionUtils.getRequiredMediaPermissions())
+        }
+    }
+
+    return CameraPermissionState(
+        hasCameraPermission = hasCameraPermission,
+        hasMediaPermissions = hasMediaPermissions,
+    )
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -876,7 +876,7 @@ class CameraViewModel @Inject constructor(
         updateUiState {
             copy(
                 avatar = avatar.copy(
-                    avatarState = currentState.avatarState.copy(isVisible = shouldShow)
+                    avatarState = avatar.avatarState.copy(isVisible = shouldShow)
                 )
             )
         }

--- a/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
+++ b/app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt
@@ -29,6 +29,7 @@ import com.example.vtubercamera.data.vrm.ErrorNotificationManager
 import com.example.vtubercamera.domain.ar.ARFeature
 import com.example.vtubercamera.domain.avatar.AvatarFeature
 import com.example.vtubercamera.domain.camera.CameraControlsFeature
+import com.example.vtubercamera.domain.camera.CameraCaptureFeature
 import com.example.vtubercamera.domain.camera.GalleryFeature
 import com.example.vtubercamera.domain.camera.LensSwitchFeature
 import com.example.vtubercamera.domain.lighting.LightingFeature
@@ -52,6 +53,7 @@ class CameraViewModel @Inject constructor(
     private val cameraRepository: CameraRepository,
     private val mediaRepository: MediaRepository,
     private val cameraControlsFeature: CameraControlsFeature,
+    private val cameraCaptureFeature: CameraCaptureFeature,
     private val galleryFeature: GalleryFeature,
     private val lensSwitchFeature: LensSwitchFeature,
     private val arFeature: ARFeature,
@@ -405,24 +407,23 @@ class CameraViewModel @Inject constructor(
         onPhotoSaved: (String) -> Unit = {},
         onError: (String) -> Unit = {}
     ) {
-        viewModelScope.launch {
-            cameraRepository.capturePhoto(
-                imageCapture = imageCapture,
-                onPhotoSaved = { uri ->
-                    val msg = "写真を保存しました: $uri"
-                    updateUiState {
-                        copy(
-                            camera = camera.copy(
-                                lastCapturedImageUri = uri,
-                            )
+        cameraCaptureFeature.capturePhoto(
+            imageCapture = imageCapture,
+            scope = viewModelScope,
+            onPhotoSaved = { uri ->
+                val msg = "写真を保存しました: $uri"
+                updateUiState {
+                    copy(
+                        camera = camera.copy(
+                            lastCapturedImageUri = uri,
                         )
-                    }
-                    onPhotoSaved(msg)
-                    refreshPhotos()
-                },
-                onError = onError
-            )
-        }
+                    )
+                }
+                onPhotoSaved(msg)
+                refreshPhotos()
+            },
+            onError = onError,
+        )
     }
 
     fun enterPreviewMode() {
@@ -646,6 +647,7 @@ class CameraViewModel @Inject constructor(
             scope = viewModelScope,
             updateUiState = this::updateUiState,
             uiStateProvider = { _uiState.value },
+            onTrackingStateChanged = this::onARTrackingStateChanged,
             startSession = { onSessionReady, onError ->
                 arSessionStarter.start(
                     context = context,
@@ -665,6 +667,7 @@ class CameraViewModel @Inject constructor(
             scope = viewModelScope,
             updateUiState = this::updateUiState,
             uiStateProvider = { _uiState.value },
+            resetAvatarState = this::resetAvatarState,
         )
     }
 
@@ -679,6 +682,8 @@ class CameraViewModel @Inject constructor(
             scope = viewModelScope,
             updateUiState = this::updateUiState,
             uiStateProvider = { _uiState.value },
+            onTrackingStateChanged = this::onARTrackingStateChanged,
+            resetAvatarState = this::resetAvatarState,
             startSession = { onSessionReady, onError ->
                 arSessionStarter.start(
                     context = context,
@@ -827,51 +832,71 @@ class CameraViewModel @Inject constructor(
             return
         }
 
-        viewModelScope.launch {
-            try {
-                Log.d("CameraViewModel", "Capturing AR photo...")
+        Log.d("CameraViewModel", "Capturing AR photo...")
 
-                // Prepare AR metadata for the photo
-                val arMetadata = com.example.vtubercamera.data.ARPhotoMetadata(
-                    avatarName = currentAvatar.value?.name,
-                    poseName = currentPose.value?.name,
-                    expressionName = currentExpression.value?.name,
-                    lightingPreset = getCurrentLightingPresetName()
-                )
+        val arMetadata = com.example.vtubercamera.data.ARPhotoMetadata(
+            avatarName = currentAvatar.value?.name,
+            poseName = currentPose.value?.name,
+            expressionName = currentExpression.value?.name,
+            lightingPreset = getCurrentLightingPresetName()
+        )
 
-                // Use new AR photo capture functionality
-                cameraRepository.captureARPhoto(
-                    imageCapture = imageCapture,
-                    arMetadata = arMetadata,
-                    onPhotoSaved = { uri ->
-                        val msg = "AR写真を保存しました: $uri"
-                        val currentState = _uiState.value
-                        _uiState.value = currentState.copy(
-                            camera = currentState.camera.copy(
-                                lastCapturedImageUri = uri
-                            )
-                        )
-                        onPhotoSaved(msg)
-                        refreshPhotos()
-                        Log.d("CameraViewModel", "AR photo captured successfully with metadata: $arMetadata")
-                    },
-                    onError = { errorMsg ->
-                        Log.e("CameraViewModel", "AR photo capture failed: $errorMsg")
-                        onError(errorMsg)
-                    }
+        cameraCaptureFeature.captureARPhoto(
+            imageCapture = imageCapture,
+            arMetadata = arMetadata,
+            scope = viewModelScope,
+            onPhotoSaved = { uri ->
+                val msg = "AR写真を保存しました: $uri"
+                val currentState = _uiState.value
+                _uiState.value = currentState.copy(
+                    camera = currentState.camera.copy(
+                        lastCapturedImageUri = uri
+                    )
                 )
-            } catch (e: Exception) {
-                Log.e("CameraViewModel", "Error capturing AR photo", e)
-                onError("AR photo capture error: ${e.message}")
-            }
-        }
+                onPhotoSaved(msg)
+                refreshPhotos()
+                Log.d("CameraViewModel", "AR photo captured successfully with metadata: $arMetadata")
+            },
+            onError = { errorMsg ->
+                Log.e("CameraViewModel", "AR photo capture failed: $errorMsg")
+                onError(errorMsg)
+            },
+        )
     }
 
     // ========== AR State Observation ==========
 
-    /**
-     * Start observing AR repository state flows
-     */
+    private fun onARTrackingStateChanged(trackingState: com.example.vtubercamera.data.vrm.TrackingState) {
+        val currentState = _uiState.value
+        if (currentState.avatarState.model == null) return
+
+        val shouldShow = trackingState == com.example.vtubercamera.data.vrm.TrackingState.TRACKING
+        if (currentState.avatarState.isVisible == shouldShow) return
+
+        updateUiState {
+            copy(
+                avatar = avatar.copy(
+                    avatarState = currentState.avatarState.copy(isVisible = shouldShow)
+                )
+            )
+        }
+    }
+
+    private fun resetAvatarState() {
+        val currentAvatarState = _uiState.value.avatarState
+        updateUiState {
+            copy(
+                avatar = avatar.copy(
+                    avatarState = currentAvatarState.copy(
+                        transform = Transform.identity(),
+                        isVisible = false,
+                    ),
+                    avatarTransform = Transform.identity(),
+                ),
+            )
+        }
+    }
+
     /**
      * Clear AR error state
      */

--- a/app/src/test/java/com/example/vtubercamera/data/vrm/FilamentARRendererTest.kt
+++ b/app/src/test/java/com/example/vtubercamera/data/vrm/FilamentARRendererTest.kt
@@ -31,6 +31,8 @@ class FilamentARRendererTest {
     private lateinit var textureManager: FilamentTextureManager
     private lateinit var lightingSystem: LightingSystem
     private lateinit var shadowSystem: ShadowSystem
+    private lateinit var lightingApplier: FilamentLightingApplier
+    private lateinit var frameCaptureService: FilamentFrameCaptureService
     private lateinit var mockSurface: Surface
     private lateinit var mockSession: Session
     private lateinit var mockFrame: Frame
@@ -43,6 +45,8 @@ class FilamentARRendererTest {
         textureManager = mock()
         lightingSystem = mock()
         shadowSystem = mock()
+        lightingApplier = FilamentLightingApplier()
+        frameCaptureService = FilamentFrameCaptureService()
 
         whenever(lightingSystem.finalLightingParameters)
             .thenReturn(MutableStateFlow(LightingParameters()))
@@ -70,7 +74,9 @@ class FilamentARRendererTest {
             materialManager,
             textureManager,
             lightingSystem,
-            shadowSystem
+            shadowSystem,
+            lightingApplier,
+            frameCaptureService,
         )
 
         mockSurface = mock()

--- a/app/src/test/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelTest.kt
+++ b/app/src/test/java/com/example/vtubercamera/ui/viewmodels/CameraViewModelTest.kt
@@ -29,6 +29,7 @@ import com.example.vtubercamera.data.vrm.LightingSettings
 import com.example.vtubercamera.domain.ar.ARFeature
 import com.example.vtubercamera.domain.avatar.AvatarFeature
 import com.example.vtubercamera.domain.camera.CameraControlsFeature
+import com.example.vtubercamera.domain.camera.CameraCaptureFeature
 import com.example.vtubercamera.domain.camera.GalleryFeature
 import com.example.vtubercamera.domain.camera.LensSwitchFeature
 import com.example.vtubercamera.domain.lighting.LightingFeature
@@ -141,6 +142,7 @@ class CameraViewModelTest {
         whenever(mockLightingSystem.getLightingPresets()).thenReturn(emptyList())
 
         val cameraControlsFeature = CameraControlsFeature()
+        val cameraCaptureFeature = CameraCaptureFeature(cameraRepository = mockCameraRepository)
         val galleryFeature = GalleryFeature(mediaRepository = mockMediaRepository)
         val lensSwitchFeature = LensSwitchFeature(cameraCapabilityManager = mockCameraCapabilityManager)
         val arFeature = ARFeature(arRepository = mockARRepository)
@@ -164,6 +166,7 @@ class CameraViewModelTest {
             cameraRepository = mockCameraRepository,
             mediaRepository = mockMediaRepository,
             cameraControlsFeature = cameraControlsFeature,
+            cameraCaptureFeature = cameraCaptureFeature,
             galleryFeature = galleryFeature,
             lensSwitchFeature = lensSwitchFeature,
             arFeature = arFeature,

--- a/docs/ANDROID_REFACTORING_CANDIDATES.ja.md
+++ b/docs/ANDROID_REFACTORING_CANDIDATES.ja.md
@@ -1,0 +1,67 @@
+# Androidアプリ設計: リファクタリング候補一覧
+
+本ドキュメントは、現行コードを確認して「設計的に優先して手を入れると効果が高い箇所」を整理したものです。
+
+## 優先度A（先に着手）
+
+1. **`CameraViewModel` の責務分割（Fat ViewModel解消）**
+   - `CameraViewModel` は 1,289 行あり、カメラ制御・ギャラリー・AR・アバター・ライティングを横断して扱っています。
+   - 単一 `UiState` を持ちながら後方互換のために多数の `StateFlow` を再公開しており、責務が集約しすぎています。
+   - 一部操作（例: `cameraRepository.capturePhoto`）が直接 ViewModel に残っており、Feature 層への移譲が中途半端です。
+   - **提案**: `CameraCaptureCoordinator` / `GalleryCoordinator` / `ARModeCoordinator` のようにユースケースごとに分割し、`CameraViewModel` はイベントルーティング中心に縮小。
+
+2. **`CameraScreen` の巨大Composable分割（UI責務の境界明確化）**
+   - `CameraScreen.kt` は 905 行で、権限要求・CameraXバインド・ダイアログ制御・トースト表示・ギャラリー表示切替まで1画面に集中しています。
+   - `remember` のローカル状態と ViewModel state が混在し、画面責務が肥大化しています。
+   - **提案**: `CameraPermissionSection` / `CameraPreviewSection` / `CameraOverlaySection` / `CameraDialogs` へ分割し、イベントを `UiEvent` として ViewModel に一本化。
+
+3. **AR境界の再設計（DomainとUI投影責務の分離）**
+   - `ARFeature` は `arRepository.destroySession()` を呼びつつ、`avatar.isVisible` や `avatarTransform` まで更新しており、セッション制御とUI投影が同居しています。
+   - **提案**: `ARFeature` は AR 状態遷移とドメインイベント発行に限定し、UIへの投影（可視/不可視・Transform初期化）は ViewModel 側に寄せる。
+
+4. **`ARRepository` インターフェースの純化（Android依存の隔離）**
+   - `ARRepository.initializeSession` が `Context` / `LifecycleOwner` を直接受け取り、インターフェース段階でプラットフォーム依存しています。
+   - **提案**: `ARSessionHost`（UI層）と `ARRepository`（データ/状態層）を分離し、ドメイン層に Android 型を漏らさない。
+
+## 優先度B（中期で改善）
+
+5. **`FilamentARRenderer` の分割（Rendererの単一責務化）**
+   - `FilamentARRenderer.kt` は 1,147 行で、初期化・描画・ライティング・シャドウ・キャプチャ・統計を1クラスで実施しています。
+   - `setLighting` / `captureFrame` にプレースホルダ実装（TODO）が残り、責務の混在が未実装要素の温床になっています。
+   - **提案**: `RenderPipeline`, `LightingApplier`, `FrameCaptureService` に分割し、未実装部分をインターフェースで明示。
+
+6. **`VRMManager` の機能分離（ロード/解析/キャッシュ責務の分割）**
+   - `VRMManager` はロード進行管理、詳細解析、複数キャッシュ、メモリ統計、検証を一括管理しています。
+   - **提案**: `VRMLoadFacade`（進行制御）, `VRMAssetCache`, `VRMValidationService` に分離してテスト容易性を上げる。
+
+7. **権限管理の重複整理（`PermissionManager` と `ARPermissionManager`）**
+   - 通常権限とAR権限で別マネージャーが存在し、権限判定ロジックの重複・分散が起こりやすい構成です。
+   - **提案**: 共通の `PermissionGateway` を作り、AR固有のARCoreインストール確認のみ `ARPermissionManager` 側に残す。
+
+## 優先度C（並行で着手可能）
+
+8. **Feature API の引数整理（`updateUiState` コールバック多用の見直し）**
+   - `CameraViewModel` から Feature 呼び出し時に `updateUiState` / `uiStateProvider` / `scope` を毎回渡しており、呼び出し規約が複雑化しています。
+   - **提案**: `CameraActionContext` のようなコンテキストオブジェクトで引数を束ね、Featureの利用面を簡潔化。
+
+9. **技術的負債（TODO）をチケット化して段階解消**
+   - VRM/AR描画周辺に TODO が多数存在し、実装完了条件が曖昧になりやすい状態です。
+   - **提案**: TODOを `must-have / nice-to-have` で分類し、描画品質に直結する項目（フレームキャプチャ、ライティング反映）を先に消化。
+
+10. **設計ドキュメントとコードの同期運用**
+    - 既にアンチパターンレビューやMVVM調査資料が存在するため、実装との差分管理を明示すると改善速度が上がります。
+    - **提案**: 「設計負債バックログ」ファイルを1つ作り、リファクタ実施ごとに更新。
+
+---
+
+## 参照した主要箇所
+- `app/src/main/java/com/example/vtubercamera/ui/viewmodels/CameraViewModel.kt`
+- `app/src/main/java/com/example/vtubercamera/ui/screens/CameraScreen.kt`
+- `app/src/main/java/com/example/vtubercamera/domain/ar/ARFeature.kt`
+- `app/src/main/java/com/example/vtubercamera/data/ARRepository.kt`
+- `app/src/main/java/com/example/vtubercamera/data/vrm/FilamentARRenderer.kt`
+- `app/src/main/java/com/example/vtubercamera/data/vrm/VRMManager.kt`
+- `app/src/main/java/com/example/vtubercamera/managers/PermissionManager.kt`
+- `app/src/main/java/com/example/vtubercamera/managers/ARPermissionManager.kt`
+- `docs/AntiPatternReview.md`
+- `docs/INVESTIGATION_MVVM_REFACTOR_SCREEN_A.md`


### PR DESCRIPTION
### Motivation
- 優先度Bタスクとして、`FilamentARRenderer` の肥大化（ライティング/キャプチャ責務）と `VRMManager` のキャッシュ責務の分散、権限判定ロジックの重複を解消するために責務分離を行いました。
- 目的は各コンポーネントを小さく保ちテスト容易性と保守性を高めることです。
- 最小安全な分割を行い既存動作のオーケストレーションを維持する形で実装しました。

### Description
- `FilamentLightingApplier` を追加して `setLighting` 内のライティング更新とシャドウ更新を移管し、`FilamentARRenderer` は注入して呼び出すだけに整理しました。
- `FilamentFrameCaptureService` を追加して `captureFrame` のプレースホルダ処理を移管し、`FilamentARRenderer` ではサービスに委譲するように変更しました。
- `VRMAssetCache` を追加してモデル/メッシュ/テクスチャ/表情/ポーズのキャッシュ処理とメモリ統計を集約し、`VRMManager` はキャッシュ参照を `VRMAssetCache` 経由へ切り替えました。
- `PermissionGateway` を新設して共通の権限判定 (`isPermissionGranted` 等) と `PermissionUtils` 連携を集中させ、`PermissionManager` を委譲型に変更し、`ARPermissionManager` は `PermissionGateway` を使うようにリファクタしました。
- Camera 層・ViewModel 側の追従変更として `CameraCaptureFeature` を追加し、`CameraViewModel` / `CameraScreen` の権限・撮影関連呼び出しを新APIに置換しました。
- 単体テストコードのセットアップを `FilamentLightingApplier` / `FilamentFrameCaptureService` に合わせて更新しました（`FilamentARRendererTest` 等）。

### Testing
- `./gradlew :app:compileDebugKotlin` を実行しましたが、実行環境で Android SDK が設定されていないためビルドは失敗しました（`SDK location not found`）。
- 単体テストスイートはローカルで実行しておらず、テストコードは依存追加に追従して修正済みです（実行は環境整備後に推奨）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699295ab0fe48330972f49d6906718c1)